### PR TITLE
Fix physics

### DIFF
--- a/8-zed/contracts/dynamics.cairo
+++ b/8-zed/contracts/dynamics.cairo
@@ -298,15 +298,10 @@ func _euler_forward_consider_hitbox{range_check_ptr}(
         let abs_relative_vx_fp = abs_value(
             physics_state_cand_0.vel_fp.x - physics_state_cand_1.vel_fp.x
         );
-        local time_required_to_separate_fp;
-        if (abs_relative_vx_fp == 0) {
-            assert time_required_to_separate_fp = abs_distance_fp_fp;
-            tempvar range_check_ptr = range_check_ptr;
-        } else {
-            let (t, _) = unsigned_div_rem(abs_distance_fp_fp, abs_relative_vx_fp);
-            assert time_required_to_separate_fp = t;
-            tempvar range_check_ptr = range_check_ptr;
-        }
+
+        let (time_required_to_separate_fp, _) = unsigned_div_rem(
+            abs_distance_fp_fp, abs_relative_vx_fp
+        );
 
         let back_off_x_0_scaled = vx_fp_cand_reversed_0 * time_required_to_separate_fp;
         let back_off_x_1_scaled = vx_fp_cand_reversed_1 * time_required_to_separate_fp;

--- a/8-zed/contracts/dynamics.cairo
+++ b/8-zed/contracts/dynamics.cairo
@@ -5,18 +5,27 @@ from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.math import abs_value, unsigned_div_rem, signed_div_rem, sign
 from starkware.cairo.common.math_cmp import is_le, is_not_zero
 from contracts.constants.constants import (
-    ns_dynamics, ns_character_type,
-    Vec2, PhysicsState, BodyState,
+    ns_dynamics,
+    ns_character_type,
+    Vec2,
+    PhysicsState,
+    BodyState,
 )
 from contracts.constants.constants_jessica import (
-    ns_jessica_dynamics, ns_jessica_character_dimension, ns_jessica_action, ns_jessica_body_state
+    ns_jessica_dynamics,
+    ns_jessica_character_dimension,
+    ns_jessica_action,
+    ns_jessica_body_state,
 )
 from contracts.constants.constants_antoc import (
-    ns_antoc_dynamics, ns_antoc_character_dimension, ns_antoc_action, ns_antoc_body_state
+    ns_antoc_dynamics,
+    ns_antoc_character_dimension,
+    ns_antoc_action,
+    ns_antoc_body_state,
 )
 from contracts.numerics import mul_fp, div_fp_ul
 
-func _character_specific_constants {range_check_ptr}(character_type: felt) -> (
+func _character_specific_constants{range_check_ptr}(character_type: felt) -> (
     MOVE_FORWARD: felt,
     MOVE_BACKWARD: felt,
     DASH_FORWARD: felt,
@@ -66,21 +75,17 @@ func _character_specific_constants {range_check_ptr}(character_type: felt) -> (
     }
 }
 
-func _euler_forward_no_hitbox {range_check_ptr}(
-    character_type: felt,
-    physics_state: PhysicsState,
-    body_state: BodyState,
-) -> (
-    physics_state_fwd: PhysicsState
-) {
+func _euler_forward_no_hitbox{range_check_ptr}(
+    character_type: felt, physics_state: PhysicsState, body_state: BodyState
+) -> (physics_state_fwd: PhysicsState) {
     alloc_locals;
 
     local vel_fp_nxt: Vec2;
 
     // unpack
-    let state   = body_state.state;
+    let state = body_state.state;
     let counter = body_state.counter;
-    let dir     = body_state.dir;
+    let dir = body_state.dir;
 
     // get character-specific constants for dynamics
     let (
@@ -97,7 +102,7 @@ func _euler_forward_no_hitbox {range_check_ptr}(
         DASH_ACC_FP: felt,
         DEACC_FP: felt,
         BODY_KNOCKED_ADJUST_W: felt,
-    ) = _character_specific_constants (character_type);
+    ) = _character_specific_constants(character_type);
 
     //
     // Set acceleration (fp) according to body state
@@ -148,17 +153,17 @@ func _euler_forward_no_hitbox {range_check_ptr}(
                 // # back off the difference between normal body sprite width and knocked sprite width
                 return (
                     PhysicsState(
-                        pos=Vec2(physics_state.pos.x - BODY_KNOCKED_ADJUST_W, physics_state.pos.y),
-                        vel_fp=Vec2(0, 0),
-                        acc_fp=Vec2(0, 0),
+                    pos=Vec2(physics_state.pos.x - BODY_KNOCKED_ADJUST_W, physics_state.pos.y),
+                    vel_fp=Vec2(0, 0),
+                    acc_fp=Vec2(0, 0),
                     ),
                 );
             } else {
                 return (
                     PhysicsState(
-                            pos=Vec2(physics_state.pos.x + 1, physics_state.pos.y),
-                            vel_fp=Vec2(0, 0),
-                            acc_fp=Vec2(0, 0),
+                    pos=Vec2(physics_state.pos.x + 1, physics_state.pos.y),
+                    vel_fp=Vec2(0, 0),
+                    acc_fp=Vec2(0, 0),
                     ),
                 );
             }
@@ -181,9 +186,9 @@ func _euler_forward_no_hitbox {range_check_ptr}(
     // otherwise, set velocity to zero (instant stop)
     return (
         PhysicsState(
-            pos=Vec2(physics_state.pos.x, physics_state.pos.y),
-            vel_fp=Vec2(0, 0),
-            acc_fp=Vec2(0, 0),
+        pos=Vec2(physics_state.pos.x, physics_state.pos.y),
+        vel_fp=Vec2(0, 0),
+        acc_fp=Vec2(0, 0),
         ),
     );
 
@@ -192,20 +197,14 @@ func _euler_forward_no_hitbox {range_check_ptr}(
     //
     update_vel_move:
     let (vel_fp_nxt_: Vec2) = _euler_forward_vel_no_hitbox(
-        physics_state.vel_fp,
-        Vec2(acc_fp_x, acc_fp_y),
-        MAX_VEL_MOVE_FP,
-        MIN_VEL_MOVE_FP,
+        physics_state.vel_fp, Vec2(acc_fp_x, acc_fp_y), MAX_VEL_MOVE_FP, MIN_VEL_MOVE_FP
     );
     assert vel_fp_nxt = vel_fp_nxt_;
     jmp update_pos;
 
     update_vel_dash:
     let (vel_fp_nxt_: Vec2) = _euler_forward_vel_no_hitbox(
-        physics_state.vel_fp,
-        Vec2(acc_fp_x, acc_fp_y),
-        MAX_VEL_DASH_FP,
-        MIN_VEL_DASH_FP,
+        physics_state.vel_fp, Vec2(acc_fp_x, acc_fp_y), MAX_VEL_DASH_FP, MIN_VEL_DASH_FP
     );
     assert vel_fp_nxt = vel_fp_nxt_;
 
@@ -216,9 +215,7 @@ func _euler_forward_no_hitbox {range_check_ptr}(
     let (pos_nxt: Vec2) = _euler_forward_pos_no_hitbox(physics_state.pos, vel_fp_nxt);
 
     let physics_state_fwd: PhysicsState = PhysicsState(
-        pos=pos_nxt,
-        vel_fp=vel_fp_nxt,
-        acc_fp=Vec2(acc_fp_x, acc_fp_y),
+        pos=pos_nxt, vel_fp=vel_fp_nxt, acc_fp=Vec2(acc_fp_x, acc_fp_y)
     );
 
     return (physics_state_fwd,);
@@ -277,10 +274,7 @@ func _euler_forward_consider_hitbox{range_check_ptr}(
     physics_state_1: PhysicsState,
     physics_state_cand_1: PhysicsState,
     bool_body_overlap: felt,
-) -> (
-    physics_state_fwd_0: PhysicsState,
-    physics_state_fwd_1: PhysicsState,
-) {
+) -> (physics_state_fwd_0: PhysicsState, physics_state_fwd_1: PhysicsState) {
     alloc_locals;
 
     if (bool_body_overlap == 1) {
@@ -335,14 +329,14 @@ func _euler_forward_consider_hitbox{range_check_ptr}(
         // note: do nothing for now to Y component
 
         let physics_state_fwd_0: PhysicsState = PhysicsState(
-            pos = Vec2(x_0, physics_state_cand_0.pos.y),
-            vel_fp = Vec2(0, 0),
-            acc_fp = physics_state_cand_0.acc_fp,
+            pos=Vec2(x_0, physics_state_cand_0.pos.y),
+            vel_fp=Vec2(0, 0),
+            acc_fp=physics_state_cand_0.acc_fp,
         );
         let physics_state_fwd_1: PhysicsState = PhysicsState(
-            pos = Vec2(x_1, physics_state_cand_1.pos.y),
-            vel_fp = Vec2(0, 0),
-            acc_fp = physics_state_cand_1.acc_fp,
+            pos=Vec2(x_1, physics_state_cand_1.pos.y),
+            vel_fp=Vec2(0, 0),
+            acc_fp=physics_state_cand_1.acc_fp,
         );
 
         return (physics_state_fwd_0, physics_state_fwd_1);

--- a/8-zed/contracts/dynamics.cairo
+++ b/8-zed/contracts/dynamics.cairo
@@ -5,27 +5,18 @@ from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.math import abs_value, unsigned_div_rem, signed_div_rem, sign
 from starkware.cairo.common.math_cmp import is_le, is_not_zero
 from contracts.constants.constants import (
-    ns_dynamics,
-    ns_character_type,
-    Vec2,
-    PhysicsState,
-    BodyState,
+    ns_dynamics, ns_character_type,
+    Vec2, PhysicsState, BodyState,
 )
 from contracts.constants.constants_jessica import (
-    ns_jessica_dynamics,
-    ns_jessica_character_dimension,
-    ns_jessica_action,
-    ns_jessica_body_state,
+    ns_jessica_dynamics, ns_jessica_character_dimension, ns_jessica_action, ns_jessica_body_state
 )
 from contracts.constants.constants_antoc import (
-    ns_antoc_dynamics,
-    ns_antoc_character_dimension,
-    ns_antoc_action,
-    ns_antoc_body_state,
+    ns_antoc_dynamics, ns_antoc_character_dimension, ns_antoc_action, ns_antoc_body_state
 )
 from contracts.numerics import mul_fp, div_fp_ul
 
-func _character_specific_constants{range_check_ptr}(character_type: felt) -> (
+func _character_specific_constants {range_check_ptr}(character_type: felt) -> (
     MOVE_FORWARD: felt,
     MOVE_BACKWARD: felt,
     DASH_FORWARD: felt,
@@ -75,17 +66,21 @@ func _character_specific_constants{range_check_ptr}(character_type: felt) -> (
     }
 }
 
-func _euler_forward_no_hitbox{range_check_ptr}(
-    character_type: felt, physics_state: PhysicsState, body_state: BodyState
-) -> (physics_state_fwd: PhysicsState) {
+func _euler_forward_no_hitbox {range_check_ptr}(
+    character_type: felt,
+    physics_state: PhysicsState,
+    body_state: BodyState,
+) -> (
+    physics_state_fwd: PhysicsState
+) {
     alloc_locals;
 
     local vel_fp_nxt: Vec2;
 
     // unpack
-    let state = body_state.state;
+    let state   = body_state.state;
     let counter = body_state.counter;
-    let dir = body_state.dir;
+    let dir     = body_state.dir;
 
     // get character-specific constants for dynamics
     let (
@@ -102,7 +97,7 @@ func _euler_forward_no_hitbox{range_check_ptr}(
         DASH_ACC_FP: felt,
         DEACC_FP: felt,
         BODY_KNOCKED_ADJUST_W: felt,
-    ) = _character_specific_constants(character_type);
+    ) = _character_specific_constants (character_type);
 
     //
     // Set acceleration (fp) according to body state

--- a/8-zed/contracts/dynamics.cairo
+++ b/8-zed/contracts/dynamics.cairo
@@ -153,17 +153,17 @@ func _euler_forward_no_hitbox{range_check_ptr}(
                 // # back off the difference between normal body sprite width and knocked sprite width
                 return (
                     PhysicsState(
-                    pos=Vec2(physics_state.pos.x - BODY_KNOCKED_ADJUST_W, physics_state.pos.y),
-                    vel_fp=Vec2(0, 0),
-                    acc_fp=Vec2(0, 0),
+                        pos=Vec2(physics_state.pos.x - BODY_KNOCKED_ADJUST_W, physics_state.pos.y),
+                        vel_fp=Vec2(0, 0),
+                        acc_fp=Vec2(0, 0),
                     ),
                 );
             } else {
                 return (
                     PhysicsState(
-                    pos=Vec2(physics_state.pos.x + 1, physics_state.pos.y),
-                    vel_fp=Vec2(0, 0),
-                    acc_fp=Vec2(0, 0),
+                            pos=Vec2(physics_state.pos.x + 1, physics_state.pos.y),
+                            vel_fp=Vec2(0, 0),
+                            acc_fp=Vec2(0, 0),
                     ),
                 );
             }
@@ -186,9 +186,9 @@ func _euler_forward_no_hitbox{range_check_ptr}(
     // otherwise, set velocity to zero (instant stop)
     return (
         PhysicsState(
-        pos=Vec2(physics_state.pos.x, physics_state.pos.y),
-        vel_fp=Vec2(0, 0),
-        acc_fp=Vec2(0, 0),
+            pos=Vec2(physics_state.pos.x, physics_state.pos.y),
+            vel_fp=Vec2(0, 0),
+            acc_fp=Vec2(0, 0),
         ),
     );
 
@@ -197,14 +197,20 @@ func _euler_forward_no_hitbox{range_check_ptr}(
     //
     update_vel_move:
     let (vel_fp_nxt_: Vec2) = _euler_forward_vel_no_hitbox(
-        physics_state.vel_fp, Vec2(acc_fp_x, acc_fp_y), MAX_VEL_MOVE_FP, MIN_VEL_MOVE_FP
+        physics_state.vel_fp,
+        Vec2(acc_fp_x, acc_fp_y),
+        MAX_VEL_MOVE_FP,
+        MIN_VEL_MOVE_FP,
     );
     assert vel_fp_nxt = vel_fp_nxt_;
     jmp update_pos;
 
     update_vel_dash:
     let (vel_fp_nxt_: Vec2) = _euler_forward_vel_no_hitbox(
-        physics_state.vel_fp, Vec2(acc_fp_x, acc_fp_y), MAX_VEL_DASH_FP, MIN_VEL_DASH_FP
+        physics_state.vel_fp,
+        Vec2(acc_fp_x, acc_fp_y),
+        MAX_VEL_DASH_FP,
+        MIN_VEL_DASH_FP,
     );
     assert vel_fp_nxt = vel_fp_nxt_;
 
@@ -215,7 +221,9 @@ func _euler_forward_no_hitbox{range_check_ptr}(
     let (pos_nxt: Vec2) = _euler_forward_pos_no_hitbox(physics_state.pos, vel_fp_nxt);
 
     let physics_state_fwd: PhysicsState = PhysicsState(
-        pos=pos_nxt, vel_fp=vel_fp_nxt, acc_fp=Vec2(acc_fp_x, acc_fp_y)
+        pos=pos_nxt,
+        vel_fp=vel_fp_nxt,
+        acc_fp=Vec2(acc_fp_x, acc_fp_y),
     );
 
     return (physics_state_fwd,);
@@ -274,7 +282,10 @@ func _euler_forward_consider_hitbox{range_check_ptr}(
     physics_state_1: PhysicsState,
     physics_state_cand_1: PhysicsState,
     bool_body_overlap: felt,
-) -> (physics_state_fwd_0: PhysicsState, physics_state_fwd_1: PhysicsState) {
+) -> (
+    physics_state_fwd_0: PhysicsState,
+    physics_state_fwd_1: PhysicsState,
+) {
     alloc_locals;
 
     if (bool_body_overlap == 1) {
@@ -324,14 +335,14 @@ func _euler_forward_consider_hitbox{range_check_ptr}(
         // note: do nothing for now to Y component
 
         let physics_state_fwd_0: PhysicsState = PhysicsState(
-            pos=Vec2(x_0, physics_state_cand_0.pos.y),
-            vel_fp=Vec2(0, 0),
-            acc_fp=physics_state_cand_0.acc_fp,
+            pos = Vec2(x_0, physics_state_cand_0.pos.y),
+            vel_fp = Vec2(0, 0),
+            acc_fp = physics_state_cand_0.acc_fp,
         );
         let physics_state_fwd_1: PhysicsState = PhysicsState(
-            pos=Vec2(x_1, physics_state_cand_1.pos.y),
-            vel_fp=Vec2(0, 0),
-            acc_fp=physics_state_cand_1.acc_fp,
+            pos = Vec2(x_1, physics_state_cand_1.pos.y),
+            vel_fp = Vec2(0, 0),
+            acc_fp = physics_state_cand_1.acc_fp,
         );
 
         return (physics_state_fwd_0, physics_state_fwd_1);

--- a/8-zed/contracts/physics.cairo
+++ b/8-zed/contracts/physics.cairo
@@ -337,18 +337,18 @@ func _test_segment_overlap{range_check_ptr}(
     // Algorithm:
     // find the segment whose left point is the smaller than the left point of the other segment;
     // call it segment-left (SL), and the other one segment-right (SR);
-    // to overlap, the left point of SR should <= the right point of SL.
+    // to overlap, the left point of SR should < the right point of SL.
     //
 
     let x0_is_sl = is_le(x0_left, x1_left);
 
     if (x0_is_sl == 1) {
         // # x0 is SL
-        let bool = is_le(x1_left, x0_right);
+        let bool = is_le(x1_left + 1, x0_right);
         return (bool,);
     } else {
         // # x1 is SL
-        let bool = is_le(x0_left, x1_right);
+        let bool = is_le(x0_left + 1, x1_right);
         return (bool,);
     }
 }

--- a/8-zed/contracts/physics.cairo
+++ b/8-zed/contracts/physics.cairo
@@ -15,10 +15,12 @@ from contracts.constants.constants import (
     Hitboxes,
 )
 from contracts.constants.constants_jessica import (
-    ns_jessica_character_dimension, ns_jessica_body_state_qualifiers
+    ns_jessica_character_dimension,
+    ns_jessica_body_state_qualifiers,
 )
 from contracts.constants.constants_antoc import (
-    ns_antoc_character_dimension, ns_antoc_body_state_qualifiers
+    ns_antoc_character_dimension,
+    ns_antoc_body_state_qualifiers,
 )
 from contracts.dynamics import _euler_forward_no_hitbox, _euler_forward_consider_hitbox
 
@@ -30,10 +32,8 @@ func _bool_or{range_check_ptr}(bool_0: felt, bool_1: felt) -> (bool: felt) {
     }
 }
 
-func is_in_various_states_given_character_type {range_check_ptr}(
-    character_type: felt,
-    state: felt,
-    counter: felt,
+func is_in_various_states_given_character_type{range_check_ptr}(
+    character_type: felt, state: felt, counter: felt
 ) -> (
     bool_body_in_atk_active: felt,
     bool_body_in_knocked_early: felt,
@@ -41,9 +41,9 @@ func is_in_various_states_given_character_type {range_check_ptr}(
     bool_body_in_block: felt,
 ) {
     if (character_type == ns_character_type.JESSICA) {
-        return ns_jessica_body_state_qualifiers.is_in_various_states (state, counter);
+        return ns_jessica_body_state_qualifiers.is_in_various_states(state, counter);
     } else {
-        return ns_antoc_body_state_qualifiers.is_in_various_states (state, counter);
+        return ns_antoc_body_state_qualifiers.is_in_various_states(state, counter);
     }
 }
 
@@ -89,13 +89,17 @@ func _physicality{range_check_ptr}(
         bool_body_in_knocked_early_0: felt,
         bool_body_in_knocked_late_0: felt,
         bool_body_in_block_0: felt,
-    ) = is_in_various_states_given_character_type (character_type_0, curr_body_state_0.state, curr_body_state_0.counter);
+    ) = is_in_various_states_given_character_type(
+        character_type_0, curr_body_state_0.state, curr_body_state_0.counter
+    );
     let (
         bool_body_in_atk_active_1: felt,
         bool_body_in_knocked_early_1: felt,
         bool_body_in_knocked_late_1: felt,
         bool_body_in_block_1: felt,
-    ) = is_in_various_states_given_character_type (character_type_1, curr_body_state_1.state, curr_body_state_1.counter);
+    ) = is_in_various_states_given_character_type(
+        character_type_1, curr_body_state_1.state, curr_body_state_1.counter
+    );
 
     local action_origin_0: Vec2;
     local action_dimension_0: Vec2;
@@ -110,18 +114,18 @@ func _physicality{range_check_ptr}(
             assert action_origin_0 = Vec2(
                 candidate_physics_state_0.pos.x + ns_jessica_character_dimension.BODY_HITBOX_W,
                 candidate_physics_state_0.pos.y + ns_jessica_character_dimension.SLASH_HITBOX_Y
-            );
+                );
         } else {
             // # facing left
             assert action_origin_0 = Vec2(
                 candidate_physics_state_0.pos.x - ns_jessica_character_dimension.SLASH_HITBOX_W,
                 candidate_physics_state_0.pos.y + ns_jessica_character_dimension.SLASH_HITBOX_Y
-            );
+                );
         }
-        assert action_dimension_0 = Vec2 (ns_jessica_character_dimension.SLASH_HITBOX_W, ns_jessica_character_dimension.SLASH_HITBOX_H);
+        assert action_dimension_0 = Vec2(ns_jessica_character_dimension.SLASH_HITBOX_W, ns_jessica_character_dimension.SLASH_HITBOX_H);
     } else {
-        assert action_origin_0 = Vec2 (ns_scene.BIGNUM, ns_scene.BIGNUM);
-        assert action_dimension_0 = Vec2 (0, 0);
+        assert action_origin_0 = Vec2(ns_scene.BIGNUM, ns_scene.BIGNUM);
+        assert action_dimension_0 = Vec2(0, 0);
     }
 
     if (bool_body_in_atk_active_1 == 1) {
@@ -130,18 +134,18 @@ func _physicality{range_check_ptr}(
             assert action_origin_1 = Vec2(
                 candidate_physics_state_1.pos.x + ns_jessica_character_dimension.BODY_HITBOX_W,
                 candidate_physics_state_1.pos.y + ns_jessica_character_dimension.SLASH_HITBOX_Y
-            );
+                );
         } else {
             // # facing left
             assert action_origin_1 = Vec2(
                 candidate_physics_state_1.pos.x - ns_jessica_character_dimension.SLASH_HITBOX_W,
                 candidate_physics_state_1.pos.y + ns_jessica_character_dimension.SLASH_HITBOX_Y
-            );
+                );
         }
-        assert action_dimension_1 = Vec2 (ns_jessica_character_dimension.SLASH_HITBOX_W, ns_jessica_character_dimension.SLASH_HITBOX_H);
+        assert action_dimension_1 = Vec2(ns_jessica_character_dimension.SLASH_HITBOX_W, ns_jessica_character_dimension.SLASH_HITBOX_H);
     } else {
-        assert action_origin_1 = Vec2 (ns_scene.BIGNUM, ns_scene.BIGNUM);
-        assert action_dimension_1 = Vec2 (0, 0);
+        assert action_origin_1 = Vec2(ns_scene.BIGNUM, ns_scene.BIGNUM);
+        assert action_dimension_1 = Vec2(0, 0);
     }
 
     // # determine body dimension (knocked state has a wider hitbox)
@@ -149,34 +153,34 @@ func _physicality{range_check_ptr}(
     local body_dim_1: Vec2;
 
     if (bool_body_in_knocked_early_0 == 1) {
-        assert body_dim_0 = Vec2 (ns_jessica_character_dimension.BODY_KNOCKED_EARLY_HITBOX_W, ns_jessica_character_dimension.BODY_KNOCKED_EARLY_HITBOX_H);
+        assert body_dim_0 = Vec2(ns_jessica_character_dimension.BODY_KNOCKED_EARLY_HITBOX_W, ns_jessica_character_dimension.BODY_KNOCKED_EARLY_HITBOX_H);
     } else {
         if (bool_body_in_knocked_late_0 == 1) {
-            assert body_dim_0 = Vec2 (ns_jessica_character_dimension.BODY_KNOCKED_LATE_HITBOX_W, ns_jessica_character_dimension.BODY_KNOCKED_LATE_HITBOX_H);
+            assert body_dim_0 = Vec2(ns_jessica_character_dimension.BODY_KNOCKED_LATE_HITBOX_W, ns_jessica_character_dimension.BODY_KNOCKED_LATE_HITBOX_H);
         } else {
-            assert body_dim_0 = Vec2 (ns_jessica_character_dimension.BODY_HITBOX_W, ns_jessica_character_dimension.BODY_HITBOX_H);
+            assert body_dim_0 = Vec2(ns_jessica_character_dimension.BODY_HITBOX_W, ns_jessica_character_dimension.BODY_HITBOX_H);
         }
     }
 
     if (bool_body_in_knocked_early_1 == 1) {
-        assert body_dim_1 = Vec2 (ns_jessica_character_dimension.BODY_KNOCKED_EARLY_HITBOX_W, ns_jessica_character_dimension.BODY_KNOCKED_EARLY_HITBOX_H);
+        assert body_dim_1 = Vec2(ns_jessica_character_dimension.BODY_KNOCKED_EARLY_HITBOX_W, ns_jessica_character_dimension.BODY_KNOCKED_EARLY_HITBOX_H);
     } else {
         if (bool_body_in_knocked_late_1 == 1) {
-            assert body_dim_1 = Vec2 (ns_jessica_character_dimension.BODY_KNOCKED_LATE_HITBOX_W, ns_jessica_character_dimension.BODY_KNOCKED_LATE_HITBOX_H);
+            assert body_dim_1 = Vec2(ns_jessica_character_dimension.BODY_KNOCKED_LATE_HITBOX_W, ns_jessica_character_dimension.BODY_KNOCKED_LATE_HITBOX_H);
         } else {
-            assert body_dim_1 = Vec2 (ns_jessica_character_dimension.BODY_HITBOX_W, ns_jessica_character_dimension.BODY_HITBOX_H);
+            assert body_dim_1 = Vec2(ns_jessica_character_dimension.BODY_HITBOX_W, ns_jessica_character_dimension.BODY_HITBOX_H);
         }
     }
 
     local hitboxes_0: Hitboxes = Hitboxes(
-        action = Rectangle (action_origin_0, action_dimension_0),
-        body = Rectangle (candidate_physics_state_0.pos, body_dim_0)
-    );
+        action=Rectangle(action_origin_0, action_dimension_0),
+        body=Rectangle(candidate_physics_state_0.pos, body_dim_0)
+        );
 
     local hitboxes_1: Hitboxes = Hitboxes(
-        action = Rectangle (action_origin_1, action_dimension_1),
-        body = Rectangle (candidate_physics_state_1.pos, body_dim_1)
-    );
+        action=Rectangle(action_origin_1, action_dimension_1),
+        body=Rectangle(candidate_physics_state_1.pos, body_dim_1)
+        );
 
     //
     // 3. Test hitbox overlaps
@@ -197,7 +201,7 @@ func _physicality{range_check_ptr}(
     //
     // 4. Movement second pass, incorporating hitbox overlap (final positions) to produce final physics states
     //
-    let (curr_physics_state_0, curr_physics_state_1) = _euler_forward_consider_hitbox (
+    let (curr_physics_state_0, curr_physics_state_1) = _euler_forward_consider_hitbox(
         last_physics_state_0,
         candidate_physics_state_0,
         last_physics_state_1,
@@ -209,32 +213,32 @@ func _physicality{range_check_ptr}(
     // 5. Produce stimuli
     // (NULL / HURT / KNOCKED / CLASH)
     //
-    let curr_stimulus_0 = produce_stimulus_given_conditions (
-        bool_self_hit = bool_agent_0_hit,
-        bool_opp_hit = bool_agent_1_hit,
-        bool_body_overlap = bool_body_overlap,
-        bool_action_overlap = bool_action_overlap,
-        bool_self_atk_active = bool_body_in_atk_active_0,
-        bool_self_block_active = bool_body_in_block_0,
-        bool_opp_atk_active = bool_body_in_atk_active_1,
-        bool_opp_block_active = bool_body_in_block_1,
-        self_integrity = curr_body_state_0.integrity,
-        self_character_type = character_type_0,
-        opp_character_type = character_type_1,
+    let curr_stimulus_0 = produce_stimulus_given_conditions(
+        bool_self_hit=bool_agent_0_hit,
+        bool_opp_hit=bool_agent_1_hit,
+        bool_body_overlap=bool_body_overlap,
+        bool_action_overlap=bool_action_overlap,
+        bool_self_atk_active=bool_body_in_atk_active_0,
+        bool_self_block_active=bool_body_in_block_0,
+        bool_opp_atk_active=bool_body_in_atk_active_1,
+        bool_opp_block_active=bool_body_in_block_1,
+        self_integrity=curr_body_state_0.integrity,
+        self_character_type=character_type_0,
+        opp_character_type=character_type_1,
     );
 
-    let curr_stimulus_1 = produce_stimulus_given_conditions (
-        bool_self_hit = bool_agent_1_hit,
-        bool_opp_hit = bool_agent_0_hit,
-        bool_body_overlap = bool_body_overlap,
-        bool_action_overlap = bool_action_overlap,
-        bool_self_atk_active = bool_body_in_atk_active_1,
-        bool_self_block_active = bool_body_in_block_1,
-        bool_opp_atk_active = bool_body_in_atk_active_0,
-        bool_opp_block_active = bool_body_in_block_0,
-        self_integrity = curr_body_state_1.integrity,
-        self_character_type = character_type_1,
-        opp_character_type = character_type_0,
+    let curr_stimulus_1 = produce_stimulus_given_conditions(
+        bool_self_hit=bool_agent_1_hit,
+        bool_opp_hit=bool_agent_0_hit,
+        bool_body_overlap=bool_body_overlap,
+        bool_action_overlap=bool_action_overlap,
+        bool_self_atk_active=bool_body_in_atk_active_1,
+        bool_self_block_active=bool_body_in_block_1,
+        bool_opp_atk_active=bool_body_in_atk_active_0,
+        bool_opp_block_active=bool_body_in_block_0,
+        self_integrity=curr_body_state_1.integrity,
+        self_character_type=character_type_1,
+        opp_character_type=character_type_0,
     );
 
     return (
@@ -247,7 +251,7 @@ func _physicality{range_check_ptr}(
     );
 }
 
-func produce_stimulus_given_conditions {range_check_ptr} (
+func produce_stimulus_given_conditions{range_check_ptr}(
     bool_self_hit: felt,
     bool_opp_hit: felt,
     bool_body_overlap: felt,
@@ -262,7 +266,7 @@ func produce_stimulus_given_conditions {range_check_ptr} (
 ) -> felt {
     alloc_locals;
 
-    let is_integrity_critical = is_le (self_integrity, ns_integrity.CRITICAL_INTEGRITY);
+    let is_integrity_critical = is_le(self_integrity, ns_integrity.CRITICAL_INTEGRITY);
 
     // when hit, HURT if not in critical integrity, KNOCKED otherwise
     if (bool_self_hit == 1) {
@@ -275,7 +279,8 @@ func produce_stimulus_given_conditions {range_check_ptr} (
 
     // when blocked, antoc-blocking-jessica knocks jessica away; otherwise HURT
     if (bool_self_atk_active == 1 and bool_opp_block_active == 1 and bool_action_overlap == 1) {
-        if (self_character_type == ns_character_type.JESSICA and opp_character_type == ns_character_type.ANTOC) {
+        if (self_character_type == ns_character_type.JESSICA and
+            opp_character_type == ns_character_type.ANTOC) {
             return ns_stimulus.KNOCKED;
         }
         return ns_stimulus.HURT;
@@ -308,7 +313,7 @@ func produce_stimulus_given_conditions {range_check_ptr} (
     return ns_stimulus.NULL;
 }
 
-func _test_rectangle_overlap {range_check_ptr}(rect_0: Rectangle, rect_1: Rectangle) -> (
+func _test_rectangle_overlap{range_check_ptr}(rect_0: Rectangle, rect_1: Rectangle) -> (
     bool: felt
 ) {
     alloc_locals;

--- a/8-zed/contracts/physics.cairo
+++ b/8-zed/contracts/physics.cairo
@@ -15,12 +15,10 @@ from contracts.constants.constants import (
     Hitboxes,
 )
 from contracts.constants.constants_jessica import (
-    ns_jessica_character_dimension,
-    ns_jessica_body_state_qualifiers,
+    ns_jessica_character_dimension, ns_jessica_body_state_qualifiers
 )
 from contracts.constants.constants_antoc import (
-    ns_antoc_character_dimension,
-    ns_antoc_body_state_qualifiers,
+    ns_antoc_character_dimension, ns_antoc_body_state_qualifiers
 )
 from contracts.dynamics import _euler_forward_no_hitbox, _euler_forward_consider_hitbox
 
@@ -32,8 +30,10 @@ func _bool_or{range_check_ptr}(bool_0: felt, bool_1: felt) -> (bool: felt) {
     }
 }
 
-func is_in_various_states_given_character_type{range_check_ptr}(
-    character_type: felt, state: felt, counter: felt
+func is_in_various_states_given_character_type {range_check_ptr}(
+    character_type: felt,
+    state: felt,
+    counter: felt,
 ) -> (
     bool_body_in_atk_active: felt,
     bool_body_in_knocked_early: felt,
@@ -41,9 +41,9 @@ func is_in_various_states_given_character_type{range_check_ptr}(
     bool_body_in_block: felt,
 ) {
     if (character_type == ns_character_type.JESSICA) {
-        return ns_jessica_body_state_qualifiers.is_in_various_states(state, counter);
+        return ns_jessica_body_state_qualifiers.is_in_various_states (state, counter);
     } else {
-        return ns_antoc_body_state_qualifiers.is_in_various_states(state, counter);
+        return ns_antoc_body_state_qualifiers.is_in_various_states (state, counter);
     }
 }
 
@@ -89,17 +89,13 @@ func _physicality{range_check_ptr}(
         bool_body_in_knocked_early_0: felt,
         bool_body_in_knocked_late_0: felt,
         bool_body_in_block_0: felt,
-    ) = is_in_various_states_given_character_type(
-        character_type_0, curr_body_state_0.state, curr_body_state_0.counter
-    );
+    ) = is_in_various_states_given_character_type (character_type_0, curr_body_state_0.state, curr_body_state_0.counter);
     let (
         bool_body_in_atk_active_1: felt,
         bool_body_in_knocked_early_1: felt,
         bool_body_in_knocked_late_1: felt,
         bool_body_in_block_1: felt,
-    ) = is_in_various_states_given_character_type(
-        character_type_1, curr_body_state_1.state, curr_body_state_1.counter
-    );
+    ) = is_in_various_states_given_character_type (character_type_1, curr_body_state_1.state, curr_body_state_1.counter);
 
     local action_origin_0: Vec2;
     local action_dimension_0: Vec2;
@@ -114,18 +110,18 @@ func _physicality{range_check_ptr}(
             assert action_origin_0 = Vec2(
                 candidate_physics_state_0.pos.x + ns_jessica_character_dimension.BODY_HITBOX_W,
                 candidate_physics_state_0.pos.y + ns_jessica_character_dimension.SLASH_HITBOX_Y
-                );
+            );
         } else {
             // # facing left
             assert action_origin_0 = Vec2(
                 candidate_physics_state_0.pos.x - ns_jessica_character_dimension.SLASH_HITBOX_W,
                 candidate_physics_state_0.pos.y + ns_jessica_character_dimension.SLASH_HITBOX_Y
-                );
+            );
         }
-        assert action_dimension_0 = Vec2(ns_jessica_character_dimension.SLASH_HITBOX_W, ns_jessica_character_dimension.SLASH_HITBOX_H);
+        assert action_dimension_0 = Vec2 (ns_jessica_character_dimension.SLASH_HITBOX_W, ns_jessica_character_dimension.SLASH_HITBOX_H);
     } else {
-        assert action_origin_0 = Vec2(ns_scene.BIGNUM, ns_scene.BIGNUM);
-        assert action_dimension_0 = Vec2(0, 0);
+        assert action_origin_0 = Vec2 (ns_scene.BIGNUM, ns_scene.BIGNUM);
+        assert action_dimension_0 = Vec2 (0, 0);
     }
 
     if (bool_body_in_atk_active_1 == 1) {
@@ -134,18 +130,18 @@ func _physicality{range_check_ptr}(
             assert action_origin_1 = Vec2(
                 candidate_physics_state_1.pos.x + ns_jessica_character_dimension.BODY_HITBOX_W,
                 candidate_physics_state_1.pos.y + ns_jessica_character_dimension.SLASH_HITBOX_Y
-                );
+            );
         } else {
             // # facing left
             assert action_origin_1 = Vec2(
                 candidate_physics_state_1.pos.x - ns_jessica_character_dimension.SLASH_HITBOX_W,
                 candidate_physics_state_1.pos.y + ns_jessica_character_dimension.SLASH_HITBOX_Y
-                );
+            );
         }
-        assert action_dimension_1 = Vec2(ns_jessica_character_dimension.SLASH_HITBOX_W, ns_jessica_character_dimension.SLASH_HITBOX_H);
+        assert action_dimension_1 = Vec2 (ns_jessica_character_dimension.SLASH_HITBOX_W, ns_jessica_character_dimension.SLASH_HITBOX_H);
     } else {
-        assert action_origin_1 = Vec2(ns_scene.BIGNUM, ns_scene.BIGNUM);
-        assert action_dimension_1 = Vec2(0, 0);
+        assert action_origin_1 = Vec2 (ns_scene.BIGNUM, ns_scene.BIGNUM);
+        assert action_dimension_1 = Vec2 (0, 0);
     }
 
     // # determine body dimension (knocked state has a wider hitbox)
@@ -153,34 +149,34 @@ func _physicality{range_check_ptr}(
     local body_dim_1: Vec2;
 
     if (bool_body_in_knocked_early_0 == 1) {
-        assert body_dim_0 = Vec2(ns_jessica_character_dimension.BODY_KNOCKED_EARLY_HITBOX_W, ns_jessica_character_dimension.BODY_KNOCKED_EARLY_HITBOX_H);
+        assert body_dim_0 = Vec2 (ns_jessica_character_dimension.BODY_KNOCKED_EARLY_HITBOX_W, ns_jessica_character_dimension.BODY_KNOCKED_EARLY_HITBOX_H);  
     } else {
         if (bool_body_in_knocked_late_0 == 1) {
-            assert body_dim_0 = Vec2(ns_jessica_character_dimension.BODY_KNOCKED_LATE_HITBOX_W, ns_jessica_character_dimension.BODY_KNOCKED_LATE_HITBOX_H);
+            assert body_dim_0 = Vec2 (ns_jessica_character_dimension.BODY_KNOCKED_LATE_HITBOX_W, ns_jessica_character_dimension.BODY_KNOCKED_LATE_HITBOX_H);
         } else {
-            assert body_dim_0 = Vec2(ns_jessica_character_dimension.BODY_HITBOX_W, ns_jessica_character_dimension.BODY_HITBOX_H);
+            assert body_dim_0 = Vec2 (ns_jessica_character_dimension.BODY_HITBOX_W, ns_jessica_character_dimension.BODY_HITBOX_H);
         }
     }
 
     if (bool_body_in_knocked_early_1 == 1) {
-        assert body_dim_1 = Vec2(ns_jessica_character_dimension.BODY_KNOCKED_EARLY_HITBOX_W, ns_jessica_character_dimension.BODY_KNOCKED_EARLY_HITBOX_H);
+        assert body_dim_1 = Vec2 (ns_jessica_character_dimension.BODY_KNOCKED_EARLY_HITBOX_W, ns_jessica_character_dimension.BODY_KNOCKED_EARLY_HITBOX_H);
     } else {
         if (bool_body_in_knocked_late_1 == 1) {
-            assert body_dim_1 = Vec2(ns_jessica_character_dimension.BODY_KNOCKED_LATE_HITBOX_W, ns_jessica_character_dimension.BODY_KNOCKED_LATE_HITBOX_H);
+            assert body_dim_1 = Vec2 (ns_jessica_character_dimension.BODY_KNOCKED_LATE_HITBOX_W, ns_jessica_character_dimension.BODY_KNOCKED_LATE_HITBOX_H);
         } else {
-            assert body_dim_1 = Vec2(ns_jessica_character_dimension.BODY_HITBOX_W, ns_jessica_character_dimension.BODY_HITBOX_H);
+            assert body_dim_1 = Vec2 (ns_jessica_character_dimension.BODY_HITBOX_W, ns_jessica_character_dimension.BODY_HITBOX_H);
         }
     }
 
     local hitboxes_0: Hitboxes = Hitboxes(
-        action=Rectangle(action_origin_0, action_dimension_0),
-        body=Rectangle(candidate_physics_state_0.pos, body_dim_0)
-        );
+        action = Rectangle (action_origin_0, action_dimension_0),
+        body = Rectangle (candidate_physics_state_0.pos, body_dim_0)
+    );
 
     local hitboxes_1: Hitboxes = Hitboxes(
-        action=Rectangle(action_origin_1, action_dimension_1),
-        body=Rectangle(candidate_physics_state_1.pos, body_dim_1)
-        );
+        action = Rectangle (action_origin_1, action_dimension_1),
+        body = Rectangle (candidate_physics_state_1.pos, body_dim_1)
+    );
 
     //
     // 3. Test hitbox overlaps
@@ -201,7 +197,7 @@ func _physicality{range_check_ptr}(
     //
     // 4. Movement second pass, incorporating hitbox overlap (final positions) to produce final physics states
     //
-    let (curr_physics_state_0, curr_physics_state_1) = _euler_forward_consider_hitbox(
+    let (curr_physics_state_0, curr_physics_state_1) = _euler_forward_consider_hitbox (
         last_physics_state_0,
         candidate_physics_state_0,
         last_physics_state_1,
@@ -213,32 +209,32 @@ func _physicality{range_check_ptr}(
     // 5. Produce stimuli
     // (NULL / HURT / KNOCKED / CLASH)
     //
-    let curr_stimulus_0 = produce_stimulus_given_conditions(
-        bool_self_hit=bool_agent_0_hit,
-        bool_opp_hit=bool_agent_1_hit,
-        bool_body_overlap=bool_body_overlap,
-        bool_action_overlap=bool_action_overlap,
-        bool_self_atk_active=bool_body_in_atk_active_0,
-        bool_self_block_active=bool_body_in_block_0,
-        bool_opp_atk_active=bool_body_in_atk_active_1,
-        bool_opp_block_active=bool_body_in_block_1,
-        self_integrity=curr_body_state_0.integrity,
-        self_character_type=character_type_0,
-        opp_character_type=character_type_1,
+    let curr_stimulus_0 = produce_stimulus_given_conditions (
+        bool_self_hit = bool_agent_0_hit,
+        bool_opp_hit = bool_agent_1_hit,
+        bool_body_overlap = bool_body_overlap,
+        bool_action_overlap = bool_action_overlap,
+        bool_self_atk_active = bool_body_in_atk_active_0,
+        bool_self_block_active = bool_body_in_block_0,
+        bool_opp_atk_active = bool_body_in_atk_active_1,
+        bool_opp_block_active = bool_body_in_block_1,
+        self_integrity = curr_body_state_0.integrity,
+        self_character_type = character_type_0,
+        opp_character_type = character_type_1,
     );
 
-    let curr_stimulus_1 = produce_stimulus_given_conditions(
-        bool_self_hit=bool_agent_1_hit,
-        bool_opp_hit=bool_agent_0_hit,
-        bool_body_overlap=bool_body_overlap,
-        bool_action_overlap=bool_action_overlap,
-        bool_self_atk_active=bool_body_in_atk_active_1,
-        bool_self_block_active=bool_body_in_block_1,
-        bool_opp_atk_active=bool_body_in_atk_active_0,
-        bool_opp_block_active=bool_body_in_block_0,
-        self_integrity=curr_body_state_1.integrity,
-        self_character_type=character_type_1,
-        opp_character_type=character_type_0,
+    let curr_stimulus_1 = produce_stimulus_given_conditions (
+        bool_self_hit = bool_agent_1_hit,
+        bool_opp_hit = bool_agent_0_hit,
+        bool_body_overlap = bool_body_overlap,
+        bool_action_overlap = bool_action_overlap,
+        bool_self_atk_active = bool_body_in_atk_active_1,
+        bool_self_block_active = bool_body_in_block_1,
+        bool_opp_atk_active = bool_body_in_atk_active_0,
+        bool_opp_block_active = bool_body_in_block_0,
+        self_integrity = curr_body_state_1.integrity,
+        self_character_type = character_type_1,
+        opp_character_type = character_type_0,
     );
 
     return (
@@ -251,7 +247,7 @@ func _physicality{range_check_ptr}(
     );
 }
 
-func produce_stimulus_given_conditions{range_check_ptr}(
+func produce_stimulus_given_conditions {range_check_ptr} (
     bool_self_hit: felt,
     bool_opp_hit: felt,
     bool_body_overlap: felt,
@@ -266,7 +262,7 @@ func produce_stimulus_given_conditions{range_check_ptr}(
 ) -> felt {
     alloc_locals;
 
-    let is_integrity_critical = is_le(self_integrity, ns_integrity.CRITICAL_INTEGRITY);
+    let is_integrity_critical = is_le (self_integrity, ns_integrity.CRITICAL_INTEGRITY);
 
     // when hit, HURT if not in critical integrity, KNOCKED otherwise
     if (bool_self_hit == 1) {
@@ -279,8 +275,7 @@ func produce_stimulus_given_conditions{range_check_ptr}(
 
     // when blocked, antoc-blocking-jessica knocks jessica away; otherwise HURT
     if (bool_self_atk_active == 1 and bool_opp_block_active == 1 and bool_action_overlap == 1) {
-        if (self_character_type == ns_character_type.JESSICA and
-            opp_character_type == ns_character_type.ANTOC) {
+       if (self_character_type == ns_character_type.JESSICA and opp_character_type == ns_character_type.ANTOC) {
             return ns_stimulus.KNOCKED;
         }
         return ns_stimulus.HURT;
@@ -313,7 +308,7 @@ func produce_stimulus_given_conditions{range_check_ptr}(
     return ns_stimulus.NULL;
 }
 
-func _test_rectangle_overlap{range_check_ptr}(rect_0: Rectangle, rect_1: Rectangle) -> (
+func _test_rectangle_overlap {range_check_ptr}(rect_0: Rectangle, rect_1: Rectangle) -> (
     bool: felt
 ) {
     alloc_locals;
@@ -335,7 +330,7 @@ func _test_rectangle_overlap{range_check_ptr}(rect_0: Rectangle, rect_1: Rectang
     return (bool_x_overlap * bool_y_overlap,);
 }
 
-func _test_segment_overlap{range_check_ptr}(
+func _test_segment_overlap {range_check_ptr}(
     x0_left: felt, x0_right: felt, x1_left: felt, x1_right: felt
 ) -> (bool: felt) {
     //

--- a/8-zed/contracts/physics.cairo
+++ b/8-zed/contracts/physics.cairo
@@ -149,7 +149,7 @@ func _physicality{range_check_ptr}(
     local body_dim_1: Vec2;
 
     if (bool_body_in_knocked_early_0 == 1) {
-        assert body_dim_0 = Vec2 (ns_jessica_character_dimension.BODY_KNOCKED_EARLY_HITBOX_W, ns_jessica_character_dimension.BODY_KNOCKED_EARLY_HITBOX_H);  
+        assert body_dim_0 = Vec2 (ns_jessica_character_dimension.BODY_KNOCKED_EARLY_HITBOX_W, ns_jessica_character_dimension.BODY_KNOCKED_EARLY_HITBOX_H);
     } else {
         if (bool_body_in_knocked_late_0 == 1) {
             assert body_dim_0 = Vec2 (ns_jessica_character_dimension.BODY_KNOCKED_LATE_HITBOX_W, ns_jessica_character_dimension.BODY_KNOCKED_LATE_HITBOX_H);
@@ -275,7 +275,7 @@ func produce_stimulus_given_conditions {range_check_ptr} (
 
     // when blocked, antoc-blocking-jessica knocks jessica away; otherwise HURT
     if (bool_self_atk_active == 1 and bool_opp_block_active == 1 and bool_action_overlap == 1) {
-       if (self_character_type == ns_character_type.JESSICA and opp_character_type == ns_character_type.ANTOC) {
+        if (self_character_type == ns_character_type.JESSICA and opp_character_type == ns_character_type.ANTOC) {
             return ns_stimulus.KNOCKED;
         }
         return ns_stimulus.HURT;


### PR DESCRIPTION
Fix the small issues in the physics engine of Shoshin:

- [x] No overlap if hitboxes adjacents.
- [x] Correct produced stimuli when agents actions overlap.