### PR TITLE
feat: include game boundaries

### DIFF
--- a/8-zed/contracts/constants/constants.cairo
+++ b/8-zed/contracts/constants/constants.cairo
@@ -22,7 +22,6 @@ namespace ns_stamina {
     const INIT_STAMINA = 1000;
 }
 
-
 namespace ns_common_stamina_effect {
     // These values are added to the players stamina, 
     // They are amortized across the entire animation


### PR DESCRIPTION
This PR adds X boundaries to the Shoshin game loop.