### PR TITLE
fix: hurt knock

### DIFF
--- a/8-zed/contracts/body/body_antoc.cairo
+++ b/8-zed/contracts/body/body_antoc.cairo
@@ -207,10 +207,6 @@ func _body_antoc {range_check_ptr}(
     if (state == ns_antoc_body_state.HURT) {
 
         // check for interruption
-        if (stimulus == ns_stimulus.HURT) {
-            // hurt again while in hurt => stay in hurt but reset counter
-            return ( body_state_nxt = BodyState(ns_antoc_body_state.HURT, 0, hurt_integrity, stamina, dir, FALSE) );
-        }
         if (stimulus == ns_stimulus.KNOCKED) {
             // knocked while in hurt => worsen into knocked
             return ( body_state_nxt = BodyState(ns_antoc_body_state.KNOCKED, 0, knocked_integrity, stamina, dir, FALSE) );
@@ -229,16 +225,6 @@ func _body_antoc {range_check_ptr}(
     // Knocked
     //
     if (state == ns_antoc_body_state.KNOCKED) {
-
-        // check for interruption
-        if (stimulus == ns_stimulus.HURT) {
-            // hurt while in knocked => stay in knocked and reset counter to a small number
-            return ( body_state_nxt = BodyState(ns_antoc_body_state.KNOCKED, 3, hurt_integrity, stamina, dir, FALSE) );
-        }
-        if (stimulus == ns_stimulus.KNOCKED) {
-            // hurt while in knocked => stay in knocked and reset counter to a small number
-            return ( body_state_nxt = BodyState(ns_antoc_body_state.KNOCKED, 3, knocked_integrity, stamina, dir, FALSE) );
-        }
 
         // if counter is full => return to Idle
         if (counter == ns_antoc_body_state_duration.KNOCKED - 1) {

--- a/8-zed/contracts/body/body_jessica.cairo
+++ b/8-zed/contracts/body/body_jessica.cairo
@@ -250,10 +250,6 @@ func _body_jessica {range_check_ptr}(
     if (state == ns_jessica_body_state.HURT) {
 
         // check for interruption
-        if (stimulus == ns_stimulus.HURT) {
-            // hurt again while in hurt => stay in hurt but reset counter
-            return ( body_state_nxt = BodyState(ns_jessica_body_state.HURT, 0, hurt_integrity, stamina, dir, FALSE) );
-        }
         if (stimulus == ns_stimulus.KNOCKED) {
             // knocked while in hurt => worsen into knocked
             return ( body_state_nxt = BodyState(ns_jessica_body_state.KNOCKED, 0, knocked_integrity, stamina, dir, FALSE) );
@@ -272,16 +268,6 @@ func _body_jessica {range_check_ptr}(
     // Knocked
     //
     if (state == ns_jessica_body_state.KNOCKED) {
-
-        // check for interruption
-        if (stimulus == ns_stimulus.HURT) {
-            // hurt while in knocked => stay in knocked and reset counter to a small number
-            return ( body_state_nxt = BodyState(ns_jessica_body_state.KNOCKED, 1, hurt_integrity, stamina, dir, FALSE) );
-        }
-        if (stimulus == ns_stimulus.KNOCKED) {
-            // hurt while in knocked => stay in knocked and reset counter to a small number
-            return ( body_state_nxt = BodyState(ns_jessica_body_state.KNOCKED, 1, knocked_integrity, stamina, dir, FALSE) );
-        }
 
         // if counter is full => return to Idle
         if (counter == ns_jessica_body_state_duration.KNOCKED - 1) {

--- a/8-zed/contracts/constants/constants_antoc.cairo
+++ b/8-zed/contracts/constants/constants_antoc.cairo
@@ -68,7 +68,7 @@ namespace ns_antoc_body_state_duration {
     const HORI = 7;
     const VERT = 10;
     const BLOCK = 6; // active for counter == 1,2,3,4
-    const HURT = 3;
+    const HURT = 2;
     const KNOCKED = 11;
     const MOVE_FORWARD = 7;
     const MOVE_BACKWARD = 6;

--- a/8-zed/contracts/constants/constants_jessica.cairo
+++ b/8-zed/contracts/constants/constants_jessica.cairo
@@ -73,7 +73,7 @@ namespace ns_jessica_body_state_duration {
     const SIDECUT = 5;
     const BLOCK = 3;
     const CLASH = 4;
-    const HURT = 3;
+    const HURT = 2;
     const KNOCKED = 11;
     const MOVE_FORWARD = 8;
     const MOVE_BACKWARD = 6;


### PR DESCRIPTION
This PR includes the following fixes:

- [x] Reduces the duration for the HURT state from 3 to 2
- [x] Makes KNOCK state and HURT state un-interruptible by a HURT stimulus (HURT state can still be interrupted by a KNOCK stimulus)