### PR TITLE
feat: build bto library script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,10 @@
 .PHONY: clean cairo-compile
 dir?=8-zed
 path?=cairo_test
-output?=compiled.json
-main?=engine.cairo
+output_shoshin?=compiled_shoshin.json
+output_bto?=compiled_bto.json
+main_shoshin?=engine.cairo
+main_bto?=bto.cairo
 
 cairo_files := $(shell find $(dir) -name "*.cairo" -path "*/contracts/*")
 lib_files := $(shell find $(dir) -name "*.cairo" -path "*/lib/*")
@@ -15,24 +17,30 @@ lib_files := $(shell find $(dir) -name "*.cairo" -path "*/lib/*")
 # - // cairo --return (xxxx:type, yyyy: type): replaces the current functions return with (xxxx:type, yyyy: type).
 # 	Must be placed under the return line.
 
-all: cairo-compile clean
+all: cairo-compile-shoshin cairo-compile-lib clean
 
 cairo-build: prepare
-	sh ./scripts/compile_cairo.sh $(path) $(main) $(cairo_files) 
+	sh ./scripts/compile_cairo.sh $(path) $(main_shoshin) $(cairo_files) 
 
 lib-build: prepare
 	sh ./scripts/compile_lib.sh $(PWD)/$(dir)/$(path)/lib $(lib_files)
+	sh ./scripts/build_lib.sh $(PWD)/$(dir)/$(path)/lib/$(main_bto)
 
-cairo-compile: cairo-build lib-build format
+cairo-compile-shoshin: cairo-build lib-build format
 	cd $(dir) && \
-	cairo-compile $(path)/$(main) --output $(output) && \
-	mv $(output) ../
+	cairo-compile $(path)/$(main_shoshin) --output $(output_shoshin) && \
+	mv $(output_shoshin) ../
+
+cairo-compile-lib: cairo-build lib-build format
+	cd $(dir) && \
+	cairo-compile $(path)/lib/$(main_bto) --output $(output_bto) && \
+	mv $(output_bto) ../
 
 format: cairo-build lib-build
 	$(eval TEMP_CAIRO_FILES = $(shell find $(dir) -name "*.cairo" -path "*/$(path)/*")) \
 	cairo-format -i $(TEMP_CAIRO_FILES)
 
-clean: cairo-compile
+clean: cairo-compile-shoshin cairo-compile-lib
 	rm -rf $(dir)/$(path)
 
 prepare: 

--- a/scripts/build_lib.sh
+++ b/scripts/build_lib.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+NEW_PATH="$1"
+echo "from cairo_test.lib.tree import Tree, BinaryOperatorTree
+from starkware.cairo.common.dict_access import DictAccess
+
+func execute_tree_chain{range_check_ptr}(
+        trees_offset_len: felt,
+        trees_offset: felt*,
+        trees: Tree*,
+        mem_len: felt,
+        mem: felt*,
+        functions: DictAccess*,
+        dict: DictAccess*,
+    ) -> felt {
+    let (output, _, _) = BinaryOperatorTree.execute_tree_chain(
+        trees_offset_len,
+        trees_offset,
+        trees,
+        mem_len,
+        mem,
+        functions,
+        dict,
+    );
+    return output;
+}" > "$NEW_PATH"


### PR DESCRIPTION
This PR updates the makefile and scripts in order to build and compile the binary tree operator library into cairo bytecode.