### PR TITLE
Add Antoc's clash state + Redesign stimulus determination logic + Make hurt & clash uninterruptible

### DIFF
--- a/8-zed/contracts/body/body_antoc.cairo
+++ b/8-zed/contracts/body/body_antoc.cairo
@@ -73,13 +73,13 @@ func _body_antoc {range_check_ptr}(
                 return ( body_state_nxt = BodyState(ns_antoc_body_state.DASH_BACKWARD, 0, integrity, updated_stamina, dir, FALSE) );
             }
         }
-        
+
         // otherwise stay in IDLE but increment counter modulo duration
         let (updated_stamina, _) = calculate_stamina_change(stamina, ns_antoc_action.NULL, ns_stamina.INIT_STAMINA, ns_character_type.ANTOC);
-        if (counter == ns_antoc_body_state_duration.IDLE - 1) {            
-                return ( body_state_nxt = BodyState(ns_antoc_body_state.IDLE, 0, integrity, updated_stamina, dir, is_fatigued) );                      
+        if (counter == ns_antoc_body_state_duration.IDLE - 1) {
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.IDLE, 0, integrity, updated_stamina, dir, is_fatigued) );
             } else {
-                return ( body_state_nxt = BodyState(ns_antoc_body_state.IDLE, counter + 1, integrity, updated_stamina, dir, is_fatigued) );            
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.IDLE, counter + 1, integrity, updated_stamina, dir, is_fatigued) );
         }
     }
 
@@ -108,7 +108,7 @@ func _body_antoc {range_check_ptr}(
                     return ( body_state_nxt = BodyState(ns_antoc_body_state.HORI, 0, integrity, updated_stamina, dir, FALSE) );
                 } else {
                     return ( body_state_nxt = BodyState(ns_antoc_body_state.IDLE, 0, integrity, stamina, dir, TRUE) );
-                }                
+                }
             }
             // otherwise return to IDLE
             return ( body_state_nxt = BodyState(ns_antoc_body_state.IDLE, 0, integrity, stamina, dir, FALSE) );
@@ -163,7 +163,7 @@ func _body_antoc {range_check_ptr}(
             if (intent == ns_antoc_action.HORI) {
                 return ( body_state_nxt = BodyState(ns_antoc_body_state.VERT, counter + 1, integrity, stamina, dir, TRUE) );
             }
-            // increment counter            
+            // increment counter
             return ( body_state_nxt = BodyState(ns_antoc_body_state.VERT, counter + 1, integrity, stamina, dir, FALSE) );
         }
 
@@ -203,14 +203,9 @@ func _body_antoc {range_check_ptr}(
 
     //
     // Hurt
+    // note: uninterruptible
     //
     if (state == ns_antoc_body_state.HURT) {
-
-        // check for interruption
-        if (stimulus == ns_stimulus.KNOCKED) {
-            // knocked while in hurt => worsen into knocked
-            return ( body_state_nxt = BodyState(ns_antoc_body_state.KNOCKED, 0, knocked_integrity, stamina, dir, FALSE) );
-        }
 
         // if counter is full => return to IDLE
         if (counter == ns_antoc_body_state_duration.HURT - 1) {
@@ -223,6 +218,7 @@ func _body_antoc {range_check_ptr}(
 
     //
     // Knocked
+    // note: uninterruptible
     //
     if (state == ns_antoc_body_state.KNOCKED) {
 
@@ -255,14 +251,14 @@ func _body_antoc {range_check_ptr}(
         if(enough_stamina == TRUE){
             if (intent == ns_antoc_action.HORI) {
                 return ( body_state_nxt = BodyState(ns_antoc_body_state.HORI, 0, integrity, updated_stamina, dir, FALSE) );
-                
+
             }
             if (intent == ns_antoc_action.VERT) {
                     return ( body_state_nxt = BodyState(ns_antoc_body_state.VERT, 0, integrity, updated_stamina, dir, FALSE) );
-                
+
             }
             if (intent == ns_antoc_action.DASH_FORWARD) {
-                    return ( body_state_nxt = BodyState(ns_antoc_body_state.DASH_FORWARD, 0, integrity, updated_stamina, dir, FALSE) );                
+                    return ( body_state_nxt = BodyState(ns_antoc_body_state.DASH_FORWARD, 0, integrity, updated_stamina, dir, FALSE) );
             }
             if (intent == ns_antoc_action.DASH_BACKWARD) {
                     return ( body_state_nxt = BodyState(ns_antoc_body_state.DASH_BACKWARD, 0, integrity, updated_stamina, dir, FALSE) );
@@ -312,11 +308,11 @@ func _body_antoc {range_check_ptr}(
             if (intent == ns_antoc_action.VERT) {
                 return ( body_state_nxt = BodyState(ns_antoc_body_state.VERT, 0, integrity, updated_stamina, dir, FALSE) );
             }
-            if (intent == ns_antoc_action.DASH_FORWARD) {             
-                return ( body_state_nxt = BodyState(ns_antoc_body_state.DASH_FORWARD, 0, integrity, updated_stamina, dir, FALSE) );             
+            if (intent == ns_antoc_action.DASH_FORWARD) {
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.DASH_FORWARD, 0, integrity, updated_stamina, dir, FALSE) );
             }
-            if (intent == ns_antoc_action.DASH_BACKWARD) {            
-                return ( body_state_nxt = BodyState(ns_antoc_body_state.DASH_BACKWARD, 0, integrity, updated_stamina, dir, FALSE) );            
+            if (intent == ns_antoc_action.DASH_BACKWARD) {
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.DASH_BACKWARD, 0, integrity, updated_stamina, dir, FALSE) );
             }
         }
 
@@ -328,7 +324,7 @@ func _body_antoc {range_check_ptr}(
                 return ( body_state_nxt = BodyState(ns_antoc_body_state.MOVE_BACKWARD, counter + 1, integrity, updated_stamina, dir, FALSE) );
             }
         }
-        
+
         // able to reverse direction immediately
         if (intent == ns_antoc_action.MOVE_FORWARD) {
             return ( body_state_nxt = BodyState(ns_antoc_body_state.MOVE_FORWARD, 0, integrity, updated_stamina, dir, FALSE) );
@@ -352,7 +348,7 @@ func _body_antoc {range_check_ptr}(
             // reset counter
             if(enough_stamina == TRUE and intent == ns_antoc_body_state.DASH_FORWARD) {
                 return ( body_state_nxt = BodyState(ns_antoc_body_state.DASH_FORWARD, 0, integrity, updated_stamina, dir, FALSE) );
-            } 
+            }
             return ( body_state_nxt = BodyState(ns_antoc_body_state.IDLE, 0, integrity, stamina, dir, TRUE) );
         }
         // increment counter
@@ -370,13 +366,29 @@ func _body_antoc {range_check_ptr}(
             // reset counter
             if(enough_stamina == TRUE and intent == ns_antoc_body_state.DASH_BACKWARD) {
                 return ( body_state_nxt = BodyState(ns_antoc_body_state.DASH_BACKWARD, 0, integrity, updated_stamina, dir, FALSE) );
-            } 
+            }
             return ( body_state_nxt = BodyState(ns_antoc_body_state.IDLE, 0, integrity, stamina, dir, TRUE) );
         }
         // increment counter
         return ( body_state_nxt = BodyState(ns_antoc_body_state.DASH_BACKWARD, counter + 1, integrity, stamina, dir, FALSE) );
     }
 
+    //
+    // Clash
+    // note: uninterruptible
+    //
+    if (state == ns_antoc_body_state.CLASH) {
+
+        // if counter is full => return to IDLE
+        if (counter == ns_antoc_body_state_duration.CLASH - 1) {
+            return ( body_state_nxt = BodyState(ns_antoc_body_state.IDLE, 0, integrity, stamina, dir, FALSE) );
+        }
+
+        // else stay in CLASH and increment counter
+        return ( body_state_nxt = BodyState(ns_antoc_body_state.CLASH, counter + 1, integrity, stamina, dir, FALSE) );
+    }
+
+    // handle exception
     with_attr error_message("Input body state is not recognized.") {
         assert 0 = 1;
     }

--- a/8-zed/contracts/body/body_jessica.cairo
+++ b/8-zed/contracts/body/body_jessica.cairo
@@ -146,7 +146,7 @@ func _body_jessica {range_check_ptr}(
                     return ( body_state_nxt = BodyState(ns_jessica_body_state.UPSWING, 0, integrity, updated_stamina, dir, FALSE) );
                 } else {
                     return ( body_state_nxt = BodyState(ns_jessica_body_state.IDLE, 0, integrity, stamina, dir, TRUE) );
-                }                
+                }
             }
             // otherwise return to IDLE
             return ( body_state_nxt = BodyState(ns_jessica_body_state.IDLE, 0, integrity, stamina, dir, FALSE) );
@@ -181,7 +181,7 @@ func _body_jessica {range_check_ptr}(
                     return ( body_state_nxt = BodyState(ns_jessica_body_state.SIDECUT, 0, integrity, updated_stamina, dir, FALSE) );
                 } else {
                     return ( body_state_nxt = BodyState(ns_jessica_body_state.IDLE, 0, integrity, stamina, dir, TRUE) );
-                }            
+                }
             }
             // otherwise return to IDLE
             return ( body_state_nxt = BodyState(ns_jessica_body_state.IDLE, 0, integrity, stamina, dir, FALSE) );
@@ -223,17 +223,9 @@ func _body_jessica {range_check_ptr}(
 
     //
     // Clash
+    // note: uninterruptible
     //
     if (state == ns_jessica_body_state.CLASH) {
-        // check for interruption
-        if (stimulus == ns_stimulus.HURT) {
-            // hurt again while in hurt => stay in hurt but reset counter
-            return ( body_state_nxt = BodyState(ns_jessica_body_state.HURT, 0, hurt_integrity, stamina, dir, FALSE) );
-        }
-        if (stimulus == ns_stimulus.KNOCKED) {
-            // knocked while in hurt => worsen into knocked
-            return ( body_state_nxt = BodyState(ns_jessica_body_state.KNOCKED, 0, knocked_integrity, stamina, dir, FALSE) );
-        }
 
         // if counter is full => return to IDLE
         if (counter == ns_jessica_body_state_duration.CLASH - 1) {
@@ -246,14 +238,9 @@ func _body_jessica {range_check_ptr}(
 
     //
     // Hurt
+    // note: uninterruptible
     //
     if (state == ns_jessica_body_state.HURT) {
-
-        // check for interruption
-        if (stimulus == ns_stimulus.KNOCKED) {
-            // knocked while in hurt => worsen into knocked
-            return ( body_state_nxt = BodyState(ns_jessica_body_state.KNOCKED, 0, knocked_integrity, stamina, dir, FALSE) );
-        }
 
         // if counter is full => return to IDLE
         if (counter == ns_jessica_body_state_duration.HURT - 1) {
@@ -266,6 +253,7 @@ func _body_jessica {range_check_ptr}(
 
     //
     // Knocked
+    // note: uninterruptible
     //
     if (state == ns_jessica_body_state.KNOCKED) {
 
@@ -295,7 +283,7 @@ func _body_jessica {range_check_ptr}(
         if (intent == ns_jessica_action.BLOCK) {
             return ( body_state_nxt = BodyState(ns_jessica_body_state.BLOCK, 0, integrity, stamina, dir, FALSE) );
         }
-        
+
         if(enough_stamina == TRUE){
             if (intent == ns_jessica_action.SLASH) {
                 return ( body_state_nxt = BodyState(ns_jessica_body_state.SLASH, 0, integrity, stamina, dir, FALSE) );
@@ -307,7 +295,7 @@ func _body_jessica {range_check_ptr}(
                 return ( body_state_nxt = BodyState(ns_jessica_body_state.SIDECUT, 0, integrity, stamina, dir, FALSE) );
             }
         }
-        
+
         // continue moving forward
         if (intent == ns_jessica_action.MOVE_FORWARD) {
             if (counter == ns_jessica_body_state_duration.MOVE_FORWARD - 1) {
@@ -406,9 +394,9 @@ func _body_jessica {range_check_ptr}(
             if(enough_stamina == TRUE and intent == ns_jessica_body_state_duration.DASH_FORWARD){
                 // reset counter
                 return ( body_state_nxt = BodyState(ns_jessica_body_state.DASH_FORWARD, 0, integrity, updated_stamina, dir, FALSE) );
-            } 
+            }
             return ( body_state_nxt = BodyState(ns_jessica_body_state.IDLE, 0, integrity, stamina, dir, TRUE) );
-        } 
+        }
         // increment counter
         return ( body_state_nxt = BodyState(ns_jessica_body_state.DASH_FORWARD, counter + 1, integrity, stamina, dir, FALSE) );
     }
@@ -440,7 +428,7 @@ func _body_jessica {range_check_ptr}(
             if(enough_stamina == TRUE and intent == ns_jessica_body_state_duration.DASH_BACKWARD) {
                 // reset counter
                 return ( body_state_nxt = BodyState(ns_jessica_body_state.DASH_BACKWARD, 0, integrity, updated_stamina, dir, FALSE) );
-            } 
+            }
             return ( body_state_nxt = BodyState(ns_jessica_body_state.IDLE, 0, integrity, stamina, dir, TRUE) );
         }
         // increment counter

--- a/8-zed/contracts/constants/constants_antoc.cairo
+++ b/8-zed/contracts/constants/constants_antoc.cairo
@@ -74,6 +74,7 @@ namespace ns_antoc_body_state_duration {
     const MOVE_BACKWARD = 6;
     const DASH_FORWARD = 4;
     const DASH_BACKWARD = 4;
+    const CLASH = 5;
 }
 
 namespace ns_antoc_body_state {
@@ -87,6 +88,7 @@ namespace ns_antoc_body_state {
     const MOVE_BACKWARD = 1100;  // 6 frames
     const DASH_FORWARD = 1110;  // 9 frames
     const DASH_BACKWARD = 1120;  // 9 frames
+    const CLASH = 1130; // 5 frames
 }
 
 namespace ns_antoc_body_state_qualifiers {

--- a/8-zed/contracts/physics.cairo
+++ b/8-zed/contracts/physics.cairo
@@ -346,9 +346,18 @@ func produce_stimulus_given_conditions {range_check_ptr} (
 ) -> felt {
     alloc_locals;
 
-    let is_integrity_critical = is_le (self_integrity, ns_integrity.CRITICAL_INTEGRITY);
+    // Stimulus determination logic:
+    // (TODO in Cairo 1.0 redesign, abstract this by defining character-specific parameters and devising a parameter-driven logic to determine stimulus)
+    // 1. (hit) when hit, get HURT if not in critical integrity, get KNOCKED otherwise
+    // 2. (block-attack) when jessica (self) attacks into antoc's block, self gets CLASH
+    // 3. (block-attack) when antoc (self) attacks into antoc's block, self gets KNOCKED
+    // 4. (block-attack) when jessica blocks antoc's attack, jessica gets CLASH, while antoc gets CLASH
+    // 5. (attack-attack) when two jessica attack into each other, both get CLASH
+    // 6. (attack-attack) when two antoc attack into each other, both get CLASH
+    // 7. (attack-attack) when jessica attack into antoc's attack, jessica gets KNOCKED, while antoc gets CLASH
 
-    // when hit, HURT if not in critical integrity, KNOCKED otherwise
+    // 1. when hit, HURT if not in critical integrity, KNOCKED otherwise
+    let is_integrity_critical = is_le (self_integrity, ns_integrity.CRITICAL_INTEGRITY);
     if (bool_self_hit == 1) {
         if (bool_self_block_active == 1) {
             return ns_stimulus.NULL;
@@ -360,34 +369,53 @@ func produce_stimulus_given_conditions {range_check_ptr} (
         }
     }
 
-    // when blocked, antoc-blocking-jessica knocks jessica away; otherwise HURT
+    // 2. (block-attack) when jessica (self) attacks into antoc's block, self gets CLASH
     if (bool_self_atk_active == 1 and bool_opp_block_active == 1 and bool_action_overlap == 1) {
+        if (self_character_type == ns_character_type.JESSICA and opp_character_type == ns_character_type.ANTOC) {
+            return ns_stimulus.CLASH;
+        }
+    }
+
+    // 3. (block-attack) when antoc (self) attacks into antoc's block, self gets KNOCKED
+    if (bool_self_atk_active == 1 and bool_opp_block_active == 1 and bool_action_overlap == 1) {
+        if (self_character_type == ns_character_type.ANTOC and opp_character_type == ns_character_type.ANTOC) {
+            return ns_stimulus.KNOCKED;
+        }
+    }
+
+    // 4. (block-attack) when jessica blocks antoc's attack, jessica gets CLASH, while antoc gets CLASH
+    if (bool_self_block_active == 1 and bool_opp_atk_active == 1 and bool_action_overlap == 1) {
+        if (self_character_type == ns_character_type.JESSICA and opp_character_type == ns_character_type.ANTOC) {
+            return ns_stimulus.CLASH;
+        }
+    }
+    if (bool_self_atk_active == 1 and bool_opp_block_active == 1 and bool_action_overlap == 1) {
+        if (self_character_type == ns_character_type.ANTOC and opp_character_type == ns_character_type.JESSICA) {
+            return ns_stimulus.CLASH;
+        }
+    }
+
+    // 5. (attack-attack) when two jessica attack into each other, both get CLASH
+    if (bool_self_atk_active == 1 and bool_opp_atk_active == 1 and bool_action_overlap == 1) {
+        if (self_character_type == ns_character_type.JESSICA and opp_character_type == ns_character_type.JESSICA) {
+            return ns_stimulus.CLASH;
+        }
+    }
+
+    // 6. (attack-attack) when two antoc attack into each other, both get CLASH
+    if (bool_self_atk_active == 1 and bool_opp_atk_active == 1 and bool_action_overlap == 1) {
+        if (self_character_type == ns_character_type.ANTOC and opp_character_type == ns_character_type.ANTOC) {
+            return ns_stimulus.CLASH;
+        }
+    }
+
+    // 7. (attack-attack) when jessica attack into antoc's attack, jessica gets KNOCKED, while antoc gets CLASH
+    if (bool_self_atk_active == 1 and bool_opp_atk_active == 1 and bool_action_overlap == 1) {
         if (self_character_type == ns_character_type.JESSICA and opp_character_type == ns_character_type.ANTOC) {
             return ns_stimulus.KNOCKED;
         }
-        return ns_stimulus.HURT;
-    }
-
-    // when clashing:
-    // - antoc is hurt if clashing with antoc
-    // - antoc is clashed if clashing with jessica
-    // - jessica is knocked if clashing with antoc
-    // - jessica is clashed if clashing with jessica
-    if (bool_self_atk_active == 1 and bool_opp_atk_active == 1 and bool_action_overlap == 1) {
-        if (self_character_type == ns_character_type.ANTOC) {
-            // I am Antoc
-            if (opp_character_type == ns_character_type.ANTOC) {
-                return ns_stimulus.HURT;
-            } else {
-                return ns_stimulus.CLASH;
-            }
-        } else {
-            // I am Jessica
-            if (opp_character_type == ns_character_type.ANTOC) {
-                return ns_stimulus.KNOCKED;
-            } else {
-                return ns_stimulus.CLASH;
-            }
+        if (self_character_type == ns_character_type.ANTOC and opp_character_type == ns_character_type.JESSICA) {
+            return ns_stimulus.CLASH;
         }
     }
 

--- a/8-zed/contracts/physics.cairo
+++ b/8-zed/contracts/physics.cairo
@@ -352,9 +352,8 @@ func produce_stimulus_given_conditions {range_check_ptr} (
     // 2. (block-attack) when jessica (self) attacks into antoc's block, self gets CLASH
     // 3. (block-attack) when antoc (self) attacks into antoc's block, self gets KNOCKED
     // 4. (block-attack) when jessica blocks antoc's attack, jessica gets CLASH, while antoc gets CLASH
-    // 5. (attack-attack) when two jessica attack into each other, both get CLASH
-    // 6. (attack-attack) when two antoc attack into each other, both get CLASH
-    // 7. (attack-attack) when jessica attack into antoc's attack, jessica gets KNOCKED, while antoc gets CLASH
+    // 5. (attack-attack) when two characters of the same type attack into each other, both get CLASH
+    // 6. (attack-attack) when jessica attack into antoc's attack, jessica gets KNOCKED, while antoc gets CLASH
 
     // 1. when hit, HURT if not in critical integrity, KNOCKED otherwise
     let is_integrity_critical = is_le (self_integrity, ns_integrity.CRITICAL_INTEGRITY);
@@ -395,21 +394,14 @@ func produce_stimulus_given_conditions {range_check_ptr} (
         }
     }
 
-    // 5. (attack-attack) when two jessica attack into each other, both get CLASH
+    // 5. (attack-attack) when two characters of the same type attack into each other, both get CLASH
     if (bool_self_atk_active == 1 and bool_opp_atk_active == 1 and bool_action_overlap == 1) {
-        if (self_character_type == ns_character_type.JESSICA and opp_character_type == ns_character_type.JESSICA) {
+        if (self_character_type == opp_character_type) {
             return ns_stimulus.CLASH;
         }
     }
 
-    // 6. (attack-attack) when two antoc attack into each other, both get CLASH
-    if (bool_self_atk_active == 1 and bool_opp_atk_active == 1 and bool_action_overlap == 1) {
-        if (self_character_type == ns_character_type.ANTOC and opp_character_type == ns_character_type.ANTOC) {
-            return ns_stimulus.CLASH;
-        }
-    }
-
-    // 7. (attack-attack) when jessica attack into antoc's attack, jessica gets KNOCKED, while antoc gets CLASH
+    // 6. (attack-attack) when jessica attack into antoc's attack, jessica gets KNOCKED, while antoc gets CLASH
     if (bool_self_atk_active == 1 and bool_opp_atk_active == 1 and bool_action_overlap == 1) {
         if (self_character_type == ns_character_type.JESSICA and opp_character_type == ns_character_type.ANTOC) {
             return ns_stimulus.KNOCKED;


### PR DESCRIPTION
This PR includes the following changes:

1. Introduce Antoc's clash state (duration = 5 frames).

2. Implement the new stimulus determination logic (in `physics.cairo::produce_stimulus_given_conditions`):
```
    1. (hit) when hit, get HURT if not in critical integrity, get KNOCKED otherwise
    2. (block-attack) when jessica (self) attacks into antoc's block, self gets CLASH
    3. (block-attack) when antoc (self) attacks into antoc's block, self gets KNOCKED
    4. (block-attack) when jessica blocks antoc's attack, jessica gets CLASH, while antoc gets CLASH
    5. (attack-attack) when two jessica attack into each other, both get CLASH
    6. (attack-attack) when two antoc attack into each other, both get CLASH
    7. (attack-attack) when jessica attack into antoc's attack, jessica gets KNOCKED, while antoc gets CLASH
```

3. Make the hurt state and clash state of all characters uninterruptible.