### PR TITLE
feat: add profiling test

### DIFF
--- a/8-zed/protostar.toml
+++ b/8-zed/protostar.toml
@@ -1,5 +1,5 @@
 [project]
-protostar-version = "0.9.1"
+protostar-version = "0.9.4"
 lib-path = "lib"
 cairo-path = ["lib/bto_cairo_git"]
 

--- a/8-zed/tests/simulation/test_profiling.cairo
+++ b/8-zed/tests/simulation/test_profiling.cairo
@@ -1,0 +1,160 @@
+%lang starknet
+
+from starkware.cairo.common.alloc import alloc
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+
+from contracts.engine import loop
+from lib.bto_cairo_git.lib.tree import Tree
+
+@external
+func __setup__{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
+    %{
+        import importlib  
+        utils = importlib.import_module("tests.utils")
+        context.parse_agent = utils.parse_agent
+    %}
+    return();
+}
+
+@external
+func test_simulation{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
+    alloc_locals;
+
+    local combos_offset_len_0: felt;
+    let (local combos_offset_0) = alloc();
+    local combos_len_1: felt;
+    let (local combos_0) = alloc();
+    local combos_offset_len_1: felt;
+    let (local combos_offset_1) = alloc();
+    local combos_len_0: felt;
+    let (local combos_1) = alloc();
+
+    local state_machine_offsets_len_0: felt;
+    let (local state_machine_offsets_0) = alloc(); 
+    local state_machine_len_0: felt;
+    let (local state_machine_0) = alloc();
+    local state_machine_offsets_len_1: felt;
+    let (local state_machine_offsets_1) = alloc(); 
+    local state_machine_len_1: felt;
+    let (local state_machine_1) = alloc();
+
+    local functions_offsets_len_0: felt;
+    let (local functions_offsets_0) = alloc();
+    local functions_len_0: felt;
+    let (local functions_0) = alloc();
+    local functions_offsets_len_1: felt;
+    let (local functions_offsets_1) = alloc();
+    local functions_len_1: felt;
+    let (local functions_1) = alloc();
+
+    local actions_len_0: felt;
+    let (local actions_0) = alloc();
+    local actions_len_1: felt;
+    let (local actions_1) = alloc();
+
+    %{
+        from starkware.cairo.lang.vm.memory_segments import MemorySegmentManager
+        memory_segments = MemorySegmentManager(memory, PRIME)
+
+        (
+            combos_offset_0,
+            combos_0,
+            state_machine_offsets_0,
+            state_machine_0,
+            functions_offsets_0,
+            functions_0,
+            actions_0,
+        ) = context.parse_agent("./experiments/advanced_agent_antoc.json");
+
+        flatten_state_machine_0 = [element for sublist in state_machine_0 for element in sublist]
+        flatten_function_0 = [element for sublist in functions_0 for element in sublist]
+
+        ids.combos_offset_len_0 = len(combos_offset_0)
+        ids.combos_len_0 = len(combos_0)
+        ids.state_machine_offsets_len_0 = len(state_machine_offsets_0)
+        ids.state_machine_len_0 = len(state_machine_0)
+        ids.functions_offsets_len_0 = len(functions_offsets_0)
+        ids.functions_len_0 = len(functions_0)
+        ids.actions_len_0 = len(actions_0)
+
+        memory_segments.write_arg(ids.combos_offset_0, combos_offset_0);
+        memory_segments.write_arg(ids.combos_0, combos_0);
+        memory_segments.write_arg(ids.state_machine_offsets_0, state_machine_offsets_0);
+        memory_segments.write_arg(ids.state_machine_0, flatten_state_machine_0);
+        memory_segments.write_arg(ids.functions_offsets_0, functions_offsets_0);
+        memory_segments.write_arg(ids.functions_0, flatten_function_0);
+        memory_segments.write_arg(ids.actions_0, actions_0);
+
+        (
+            combos_offset_1,
+            combos_1,
+            state_machine_offsets_1,
+            state_machine_1,
+            functions_offsets_1,
+            functions_1,
+            actions_1,
+        ) = context.parse_agent("./experiments/advanced_agent_jessica.json");
+
+        flatten_state_machine_1 = [element for sublist in state_machine_1 for element in sublist]
+        flatten_function_1 = [element for sublist in functions_1 for element in sublist]
+
+        ids.combos_offset_len_1 = len(combos_offset_1)
+        ids.combos_len_1 = len(combos_1)
+        ids.state_machine_offsets_len_1 = len(state_machine_offsets_1)
+        ids.state_machine_len_1 = len(state_machine_1)
+        ids.functions_offsets_len_1 = len(functions_offsets_1)
+        ids.functions_len_1 = len(functions_1)
+        ids.actions_len_1 = len(actions_1)
+
+        memory_segments.write_arg(ids.combos_offset_1, combos_offset_1);
+        memory_segments.write_arg(ids.combos_1, combos_1);
+        memory_segments.write_arg(ids.state_machine_offsets_1, state_machine_offsets_1);
+        memory_segments.write_arg(ids.state_machine_1, flatten_state_machine_1);
+        memory_segments.write_arg(ids.functions_offsets_1, functions_offsets_1);
+        memory_segments.write_arg(ids.functions_1, flatten_function_1);
+        memory_segments.write_arg(ids.actions_1, actions_1);
+    %}
+
+    let tree_state_machine_0 = cast(state_machine_0, Tree*);
+    let tree_state_machine_1 = cast(state_machine_1, Tree*);
+    let tree_functions_0 = cast(functions_0, Tree*);
+    let tree_functions_1 = cast(functions_1, Tree*);
+
+    loop(
+        120, 
+        combos_offset_len_0, 
+        combos_offset_0, 
+        combos_len_0, 
+        combos_0, 
+        combos_offset_len_1, 
+        combos_offset_1, 
+        combos_len_1, 
+        combos_1, 
+        state_machine_offsets_len_0, 
+        state_machine_offsets_0, 
+        state_machine_len_0, 
+        tree_state_machine_0, 
+        0, 
+        state_machine_offsets_len_1, 
+        state_machine_offsets_1, 
+        state_machine_len_1, 
+        tree_state_machine_1, 
+        0, 
+        functions_offsets_len_0, 
+        functions_offsets_0, 
+        functions_len_0, 
+        tree_functions_0, 
+        functions_offsets_len_1, 
+        functions_offsets_1, 
+        functions_len_1, 
+        tree_functions_1, 
+        actions_len_0, 
+        actions_0, 
+        actions_len_1, 
+        actions_1, 
+        1, 
+        0
+    );
+    
+    return();
+}

--- a/8-zed/tests/test_engine.py
+++ b/8-zed/tests/test_engine.py
@@ -1,10 +1,11 @@
-import pytest
-import os
-import json
-from starkware.starknet.testing.starknet import Starknet
 import asyncio
-from utils import import_json, parse_stages, parse_mental_to_action
+import json
 import logging
+import os
+
+import pytest
+from starkware.starknet.testing.starknet import Starknet
+from utils import adjust_from_felt, parse_agent
 
 LOGGER = logging.getLogger(__name__)
 
@@ -13,55 +14,6 @@ NO = 0
 NUM_SIGNING_ACCOUNTS = 0  ## 2 angel and 2 players
 DUMMY_PRIVATE = 9812304879503423120395
 users = []
-
-PRIME = 3618502788666131213697322783095070105623107215331596699973092056135872020481
-PRIME_HALF = PRIME // 2
-
-
-def adjust_from_felt(felt):
-    if felt > PRIME_HALF:
-        return felt - PRIME
-    else:
-        return felt
-
-
-def parse_agent(path: str):
-    data = import_json(path)
-    # parse the mental state
-    mental_states_keys = data["mental_state_to_action"].keys()
-    mental_states = []
-    for k in mental_states_keys:
-        mental_states.append(data["mental_states"][k]["stages"])
-    [state_machine, state_machine_offsets] = parse_stages(
-        data["mapping"], mental_states
-    )
-    # parse the general functions
-    general_functions = data["general_purpose_functions"]
-    [functions, functions_offsets] = parse_stages(data["mapping"], general_functions)
-
-    # parse the state to actions
-    actions = parse_mental_to_action(
-        data["mapping"], data["mental_state_to_action"].values()
-    )
-
-    state_machine = [a.to_tuple() for a in state_machine]
-    functions = [a.to_tuple() for a in functions]
-    # parse the combos
-    combos = data["combos"]
-    accumulator = 0
-    combos_offset = [0]
-    list(
-        map(combos_offset.append, [accumulator := len(x) + accumulator for x in combos])
-    )
-    return (
-        combos_offset,
-        [x for a in combos for x in a],
-        state_machine_offsets,
-        state_machine,
-        [x for (i, x) in enumerate(functions_offsets) if (i + 1) % 2 == 0],
-        functions,
-        actions,
-    )
 
 
 ### Reference: https://github.com/perama-v/GoL2/blob/main/tests/test_GoL2_infinite.py

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,10 @@ lib_files := $(shell find $(dir) -name "*.cairo" -path "*/lib/*")
 
 all: cairo-compile-shoshin cairo-compile-lib clean
 
+profiling:
+	cd $(dir) && \
+	protostar test tests/simulation/test_profiling.cairo --profiling
+
 cairo-build: prepare
 	sh ./scripts/compile_cairo.sh $(path) $(main_shoshin) $(cairo_files) 
 


### PR DESCRIPTION
This PR adds profiling using protostar. To run profiling, you should have protostar version 0.9.4 and run make profiling. Please note that profiling can be quite long, taking up to 3 hours on some machines.