### PR TITLE
Adjust placement of active hitboxes to guarantee overlap

### DIFF
--- a/8-zed/contracts/constants/constants.cairo
+++ b/8-zed/contracts/constants/constants.cairo
@@ -55,6 +55,9 @@ namespace ns_stimulus {
     const CLASH = 3;
 }
 
+namespace ns_hitbox {
+    const NUDGE = 5;
+}
 
 struct Vec2 {
     x: felt,

--- a/8-zed/contracts/physics.cairo
+++ b/8-zed/contracts/physics.cairo
@@ -13,6 +13,7 @@ from contracts.constants.constants import (
     PhysicsState,
     BodyState,
     Hitboxes,
+    ns_hitbox,
 )
 from contracts.constants.constants_jessica import (
     ns_jessica_character_dimension, ns_jessica_body_state_qualifiers, ns_jessica_hitbox
@@ -127,13 +128,13 @@ func _physicality{range_check_ptr}(
             if (curr_body_state_0.dir == 1) {
                 // # facing right
                 assert action_origin_0 = Vec2(
-                    candidate_physics_state_0.pos.x + ns_jessica_character_dimension.BODY_HITBOX_W,
+                    candidate_physics_state_0.pos.x + ns_jessica_character_dimension.BODY_HITBOX_W - ns_hitbox.NUDGE,
                     candidate_physics_state_0.pos.y + ns_jessica_character_dimension.SLASH_HITBOX_Y
                 );
             } else {
                 // # facing left
                 assert action_origin_0 = Vec2(
-                    candidate_physics_state_0.pos.x - ns_jessica_character_dimension.SLASH_HITBOX_W,
+                    candidate_physics_state_0.pos.x - ns_jessica_character_dimension.SLASH_HITBOX_W + ns_hitbox.NUDGE,
                     candidate_physics_state_0.pos.y + ns_jessica_character_dimension.SLASH_HITBOX_Y
                 );
             }
@@ -144,13 +145,13 @@ func _physicality{range_check_ptr}(
             if (curr_body_state_0.dir == 1) {
                 // # facing right
                 assert action_origin_0 = Vec2(
-                    candidate_physics_state_0.pos.x + ns_jessica_character_dimension.BODY_HITBOX_W,
+                    candidate_physics_state_0.pos.x + ns_jessica_character_dimension.BODY_HITBOX_W - ns_hitbox.NUDGE,
                     candidate_physics_state_0.pos.y + ns_jessica_character_dimension.BLOCK_HITBOX_Y
                 );
             } else {
                 // # facing left
                 assert action_origin_0 = Vec2(
-                    candidate_physics_state_0.pos.x - ns_jessica_character_dimension.BLOCK_HITBOX_W,
+                    candidate_physics_state_0.pos.x - ns_jessica_character_dimension.BLOCK_HITBOX_W + ns_hitbox.NUDGE,
                     candidate_physics_state_0.pos.y + ns_jessica_character_dimension.BLOCK_HITBOX_Y
                 );
             }
@@ -168,13 +169,13 @@ func _physicality{range_check_ptr}(
             if (curr_body_state_1.dir == 1) {
                 // # facing right
                 assert action_origin_1 = Vec2(
-                    candidate_physics_state_1.pos.x + ns_jessica_character_dimension.BODY_HITBOX_W,
+                    candidate_physics_state_1.pos.x + ns_jessica_character_dimension.BODY_HITBOX_W - ns_hitbox.NUDGE,
                     candidate_physics_state_1.pos.y + ns_jessica_character_dimension.SLASH_HITBOX_Y
                 );
             } else {
                 // # facing left
                 assert action_origin_1 = Vec2(
-                    candidate_physics_state_1.pos.x - ns_jessica_character_dimension.SLASH_HITBOX_W,
+                    candidate_physics_state_1.pos.x - ns_jessica_character_dimension.SLASH_HITBOX_W + ns_hitbox.NUDGE,
                     candidate_physics_state_1.pos.y + ns_jessica_character_dimension.SLASH_HITBOX_Y
                 );
             }
@@ -185,13 +186,13 @@ func _physicality{range_check_ptr}(
             if (curr_body_state_1.dir == 1) {
                 // # facing right
                 assert action_origin_1 = Vec2(
-                    candidate_physics_state_1.pos.x + ns_jessica_character_dimension.BODY_HITBOX_W,
+                    candidate_physics_state_1.pos.x + ns_jessica_character_dimension.BODY_HITBOX_W - ns_hitbox.NUDGE,
                     candidate_physics_state_1.pos.y + ns_jessica_character_dimension.BLOCK_HITBOX_Y
                 );
             } else {
                 // # facing left
                 assert action_origin_1 = Vec2(
-                    candidate_physics_state_1.pos.x - ns_jessica_character_dimension.BLOCK_HITBOX_W,
+                    candidate_physics_state_1.pos.x - ns_jessica_character_dimension.BLOCK_HITBOX_W + ns_hitbox.NUDGE,
                     candidate_physics_state_1.pos.y + ns_jessica_character_dimension.BLOCK_HITBOX_Y
                 );
             }


### PR DESCRIPTION
This PR nudges the block hitbox a little bit inside the blocker, and the offensive hitbox a little bit inside the attack, so that overlap is guaranteed.

The corresponding PR on the frontend is https://github.com/topology-gg/shoshin-tooling/pull/131