### PR TITLE
Improve direction switch handling

### DIFF
--- a/8-zed/contracts/constants/constants.cairo
+++ b/8-zed/contracts/constants/constants.cairo
@@ -2,6 +2,9 @@
 
 from starkware.cairo.common.cairo_builtins import HashBuiltin
 
+const LEFT = 0;
+const RIGHT = 1;
+
 namespace ns_character_type {
     const JESSICA = 0;
     const ANTOC = 1;

--- a/8-zed/contracts/numerics.cairo
+++ b/8-zed/contracts/numerics.cairo
@@ -9,6 +9,14 @@ const SCALE_FP = ns_dynamics.SCALE_FP;
 const SCALE_FP_SQRT = ns_dynamics.SCALE_FP_SQRT;
 const RANGE_CHECK_BOUND = ns_dynamics.RANGE_CHECK_BOUND;
 
+func bool_inv{range_check_ptr}(x: felt) -> felt {
+    if (x==0) {
+        return 1;
+    } else {
+        return 0;
+    }
+}
+
 //
 // Utility functions for fixed-point arithmetic
 //


### PR DESCRIPTION
This PR improves the logic that handles direction switching.

More specifically, the sign of the difference between the two characters' x coordinates is used to determine the correct direction for each character. The direction switch happens when body counter is 0, effectively switching direction at the first frame of the next move.