### PR TITLE
Make only first 6 frames of launched interruptible

### DIFF
--- a/8-zed/contracts/body/body_antoc.cairo
+++ b/8-zed/contracts/body/body_antoc.cairo
@@ -698,13 +698,16 @@ func _body_antoc {range_check_ptr}(
     //
     if (state == ns_antoc_body_state.LAUNCHED) {
 
-        // can be knocked
-        if (stimulus_type == ns_stimulus.KNOCKED) {
-            return ( body_state_nxt = BodyState(ns_antoc_body_state.KNOCKED, 0, updated_integrity, stamina, dir, FALSE) );
-        }
-        // can be juggled
-        if (stimulus_type == ns_stimulus.LAUNCHED) {
-            return ( body_state_nxt = BodyState(ns_antoc_body_state.LAUNCHED, 0, updated_integrity, stamina, dir, FALSE) );
+        // if within first 6 frames => can be interrupted
+        if ( (counter-0) * (counter-1) * (counter-2) * (counter-3) * (counter-4) * (counter-5) == 0 ) {
+            // can be knocked
+            if (stimulus_type == ns_stimulus.KNOCKED) {
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.KNOCKED, 0, updated_integrity, stamina, dir, FALSE) );
+            }
+            // can be re-launched ie juggled
+            if (stimulus_type == ns_stimulus.LAUNCHED) {
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.LAUNCHED, 0, updated_integrity, stamina, dir, FALSE) );
+            }
         }
 
         // if counter is full => return to IDLE

--- a/8-zed/contracts/body/body_jessica.cairo
+++ b/8-zed/contracts/body/body_jessica.cairo
@@ -710,13 +710,16 @@ func _body_jessica {range_check_ptr}(
     //
     if (state == ns_jessica_body_state.LAUNCHED) {
 
-        // can be knocked
-        if (stimulus_type == ns_stimulus.KNOCKED) {
-            return ( body_state_nxt = BodyState(ns_jessica_body_state.KNOCKED, 0, updated_integrity, stamina, dir, FALSE) );
-        }
-        // can be juggled
-        if (stimulus_type == ns_stimulus.LAUNCHED) {
-            return ( body_state_nxt = BodyState(ns_jessica_body_state.LAUNCHED, 0, updated_integrity, stamina, dir, FALSE) );
+        // if within first 6 frames => can be interrupted
+        if ( (counter-0) * (counter-1) * (counter-2) * (counter-3) * (counter-4) * (counter-5) == 0 ) {
+            // can be knocked
+            if (stimulus_type == ns_stimulus.KNOCKED) {
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.KNOCKED, 0, updated_integrity, stamina, dir, FALSE) );
+            }
+            // can be re-launched ie juggled
+            if (stimulus_type == ns_stimulus.LAUNCHED) {
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.LAUNCHED, 0, updated_integrity, stamina, dir, FALSE) );
+            }
         }
 
         // if counter is full => return to IDLE

--- a/8-zed/contracts/constants/constants_antoc.cairo
+++ b/8-zed/contracts/constants/constants_antoc.cairo
@@ -288,7 +288,7 @@ namespace ns_antoc_hitbox {
     ) {
         alloc_locals;
 
-        // knocked
+        // knocked or launched
         if ( (body_state-ns_antoc_body_state.KNOCKED) * (body_state-ns_antoc_body_state.LAUNCHED) == 0 ) {
             let is_counter_le_0 = is_le(body_counter, 0);
             if (is_counter_le_0== 1) {

--- a/8-zed/contracts/constants/constants_jessica.cairo
+++ b/8-zed/contracts/constants/constants_jessica.cairo
@@ -290,7 +290,7 @@ namespace ns_jessica_hitbox {
     ) {
         alloc_locals;
 
-        // knocked
+        // knocked or launched
         if ( (body_state-ns_jessica_body_state.KNOCKED) * (body_state-ns_jessica_body_state.LAUNCHED) == 0 ) {
             let is_counter_le_1 = is_le(body_counter, 1);
             if (is_counter_le_1 == 1) {


### PR DESCRIPTION
This PR makes only the first 6 frames of LAUNCHED state interruptible, effectively making the rest of the LAUNCHED frames invincible. This helps reduce upswing spams working as infinite combo.