### PR TITLE
Multi active frame

### DIFF
--- a/8-zed/contracts/body/body.cairo
+++ b/8-zed/contracts/body/body.cairo
@@ -9,19 +9,23 @@ from contracts.body.body_jessica import _body_jessica
 from contracts.body.body_antoc import _body_antoc
 
 func _body{range_check_ptr}(
-        character_type: felt, body_state: BodyState, stimulus: felt, intent: felt
+        character_type: felt,
+        body_state: BodyState,
+        stimulus: felt,
+        intent: felt,
+        opponent_body_state_index: felt,
     ) -> (
         body_state_nxt: BodyState
 ) {
     if (character_type == ns_character_type.JESSICA) {
-        return _body_jessica (body_state, stimulus, intent);
+        return _body_jessica (body_state, stimulus, intent, opponent_body_state_index);
     }
     if (character_type == ns_character_type.ANTOC) {
-        return _body_antoc (body_state, stimulus, intent);
+        return _body_antoc (body_state, stimulus, intent, opponent_body_state_index);
     }
 
     with_attr error_message("Character type is not recognized.") {
         assert 0 = 1;
     }
-    return ( body_state_nxt = BodyState(0,0,0,0,0,0) );
+    return ( body_state_nxt = BodyState(0,0,0,0,0,0,0,0) );
 }

--- a/8-zed/contracts/body/body_antoc.cairo
+++ b/8-zed/contracts/body/body_antoc.cairo
@@ -4,6 +4,7 @@ from starkware.cairo.common.cairo_builtins import HashBuiltin
 from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.bool import (TRUE, FALSE)
 from starkware.cairo.common.math import unsigned_div_rem
+from starkware.cairo.common.math_cmp import is_le, is_nn_le, is_not_zero
 from contracts.constants.constants import (
     BodyState, ns_stimulus, ns_stamina, ns_character_type, HURT_EFFECT, KNOCKED_EFFECT, CLASH_EFFECT
 )
@@ -18,7 +19,10 @@ from contracts.body.body_utils import (
 // Antoc's Body State Diagram
 //
 func _body_antoc {range_check_ptr}(
-        body_state: BodyState, stimulus: felt, intent: felt
+        body_state: BodyState,
+        stimulus: felt,
+        intent: felt,
+        opponent_body_state_index: felt,
     ) -> (
         body_state_nxt: BodyState
 ) {
@@ -30,6 +34,8 @@ func _body_antoc {range_check_ptr}(
     let integrity = body_state.integrity;
     let stamina = body_state.stamina;
     let dir = body_state.dir;
+    let state_index = body_state.state_index;
+    let opponent_state_index_last_hit = body_state.opponent_state_index_last_hit;
 
     // Decode stimulus
     let (stimulus_type, stimulus_damage) = unsigned_div_rem (stimulus, ns_stimulus.ENCODING);
@@ -39,20 +45,24 @@ func _body_antoc {range_check_ptr}(
     let (updated_stamina, enough_stamina) = calculate_stamina_change (stamina, intent, ns_stamina.MAX_STAMINA, ns_character_type.ANTOC);
     let is_fatigued = 1 - enough_stamina;
 
+    // Check if opponent's state_index has progressed from opponent_state_index_last_hit;
+    // for preventing incorrectly registering more than one hit per attack move
+    let opponent_state_index_has_progressed = is_not_zero (opponent_body_state_index - opponent_state_index_last_hit);
+
     //
     // KO
     // not interruptible; not responding to intent
     //
     if (updated_integrity == 0 and state != ns_antoc_body_state.KO) {
-        return ( body_state_nxt = BodyState(ns_antoc_body_state.KO, 0, updated_integrity , stamina, dir, FALSE) );
+        return ( body_state_nxt = BodyState(ns_antoc_body_state.KO, 0, updated_integrity , stamina, dir, FALSE, state_index+1, opponent_body_state_index) );
     }
     if (state == ns_antoc_body_state.KO) {
         if (counter == ns_antoc_body_state_duration.KO - 1) {
             // stop at last frame
-            return ( body_state_nxt = BodyState(ns_antoc_body_state.KO, counter, updated_integrity, updated_stamina, dir, is_fatigued) );
+            return ( body_state_nxt = BodyState(ns_antoc_body_state.KO, counter, updated_integrity, updated_stamina, dir, is_fatigued, state_index, opponent_state_index_last_hit) );
         } else {
             // increment
-            return ( body_state_nxt = BodyState(ns_antoc_body_state.KO, counter + 1, updated_integrity, updated_stamina, dir, is_fatigued) );
+            return ( body_state_nxt = BodyState(ns_antoc_body_state.KO, counter + 1, updated_integrity, updated_stamina, dir, is_fatigued, state_index, opponent_state_index_last_hit) );
         }
     }
 
@@ -61,62 +71,64 @@ func _body_antoc {range_check_ptr}(
     //
     if (state == ns_antoc_body_state.IDLE) {
         // body responds to stimulus first
-        if (stimulus_type == ns_stimulus.HURT) {
-            return ( body_state_nxt = BodyState(ns_antoc_body_state.HURT, 0, updated_integrity , stamina, dir, FALSE) );
-        }
-        if (stimulus_type == ns_stimulus.KNOCKED) {
-            return ( body_state_nxt = BodyState(ns_antoc_body_state.KNOCKED, 0, updated_integrity, stamina, dir, FALSE) );
-        }
-        if (stimulus_type == ns_stimulus.LAUNCHED) {
-            return ( body_state_nxt = BodyState(ns_antoc_body_state.LAUNCHED, 0, updated_integrity, stamina, dir, FALSE) );
+        if (opponent_state_index_has_progressed == 1) {
+            if (stimulus_type == ns_stimulus.HURT) {
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.HURT, 0, updated_integrity , stamina, dir, FALSE, state_index+1, opponent_body_state_index) );
+            }
+            if (stimulus_type == ns_stimulus.KNOCKED) {
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.KNOCKED, 0, updated_integrity, stamina, dir, FALSE, state_index+1, opponent_body_state_index) );
+            }
+            if (stimulus_type == ns_stimulus.LAUNCHED) {
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.LAUNCHED, 0, updated_integrity, stamina, dir, FALSE, state_index+1, opponent_body_state_index) );
+            }
         }
 
         // body responds to intent; locomotive action has lowest priority
         if (intent == ns_antoc_action.TAUNT) {
-            return ( body_state_nxt = BodyState(ns_antoc_body_state.TAUNT_PARIS23, 0, integrity, updated_stamina, dir, FALSE) );
+            return ( body_state_nxt = BodyState(ns_antoc_body_state.TAUNT_PARIS23, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
         }
         if (intent == ns_antoc_action.MOVE_FORWARD) {
-            return ( body_state_nxt = BodyState(ns_antoc_body_state.MOVE_FORWARD, 0, integrity, updated_stamina, dir, FALSE) );
+            return ( body_state_nxt = BodyState(ns_antoc_body_state.MOVE_FORWARD, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
         }
         if (intent == ns_antoc_action.MOVE_BACKWARD) {
-            return ( body_state_nxt = BodyState(ns_antoc_body_state.MOVE_BACKWARD, 0, integrity, updated_stamina, dir, FALSE) );
+            return ( body_state_nxt = BodyState(ns_antoc_body_state.MOVE_BACKWARD, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
         }
         if (intent == ns_antoc_action.BLOCK) {
-            return ( body_state_nxt = BodyState(ns_antoc_body_state.BLOCK, 0, integrity, updated_stamina, dir, FALSE) );
+            return ( body_state_nxt = BodyState(ns_antoc_body_state.BLOCK, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
         }
         if(enough_stamina == TRUE){
             if (intent == ns_antoc_action.HORI) {
-                return ( body_state_nxt = BodyState(ns_antoc_body_state.HORI, 0, integrity, updated_stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.HORI, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
             if (intent == ns_antoc_action.VERT) {
-                return ( body_state_nxt = BodyState(ns_antoc_body_state.VERT, 0, integrity, updated_stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.VERT, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
             if (intent == ns_antoc_action.LOW_KICK) {
-                return ( body_state_nxt = BodyState(ns_antoc_body_state.LOW_KICK, 0, integrity, updated_stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.LOW_KICK, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
             if (intent == ns_antoc_action.DASH_FORWARD) {
-                return ( body_state_nxt = BodyState(ns_antoc_body_state.DASH_FORWARD, 0, integrity, updated_stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.DASH_FORWARD, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
             if (intent == ns_antoc_action.DASH_BACKWARD) {
-                return ( body_state_nxt = BodyState(ns_antoc_body_state.DASH_BACKWARD, 0, integrity, updated_stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.DASH_BACKWARD, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
             if (intent == ns_antoc_action.JUMP) {
-                return ( body_state_nxt = BodyState(ns_antoc_body_state.JUMP, 0, integrity, updated_stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.JUMP, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
             if (intent == ns_antoc_action.STEP_FORWARD) {
-                return ( body_state_nxt = BodyState(ns_antoc_body_state.STEP_FORWARD, 0, integrity, updated_stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.STEP_FORWARD, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
             if (intent == ns_antoc_action.CYCLONE) {
-                return ( body_state_nxt = BodyState(ns_antoc_body_state.CYCLONE, 0, integrity, updated_stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.CYCLONE, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
         }
 
         // otherwise stay in IDLE but increment counter modulo duration
         let (updated_stamina, _) = calculate_stamina_change(stamina, ns_antoc_action.NULL, ns_stamina.MAX_STAMINA, ns_character_type.ANTOC);
         if (counter == ns_antoc_body_state_duration.IDLE - 1) {
-                return ( body_state_nxt = BodyState(ns_antoc_body_state.IDLE, 0, integrity, updated_stamina, dir, is_fatigued) );
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.IDLE, 0, integrity, updated_stamina, dir, is_fatigued, state_index, opponent_state_index_last_hit) );
             } else {
-                return ( body_state_nxt = BodyState(ns_antoc_body_state.IDLE, counter + 1, integrity, updated_stamina, dir, is_fatigued) );
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.IDLE, counter + 1, integrity, updated_stamina, dir, is_fatigued, state_index, opponent_state_index_last_hit) );
         }
     }
 
@@ -126,17 +138,19 @@ func _body_antoc {range_check_ptr}(
     if (state == ns_antoc_body_state.HORI) {
 
         // body responds to stimulus first
-        if (stimulus_type == ns_stimulus.HURT) {
-            return ( body_state_nxt = BodyState(ns_antoc_body_state.HURT, 0, updated_integrity, stamina, dir, FALSE) );
-        }
-        if (stimulus_type == ns_stimulus.KNOCKED) {
-            return ( body_state_nxt = BodyState(ns_antoc_body_state.KNOCKED, 0, updated_integrity, stamina, dir, FALSE) );
-        }
-        if (stimulus_type == ns_stimulus.LAUNCHED) {
-            return ( body_state_nxt = BodyState(ns_antoc_body_state.LAUNCHED, 0, updated_integrity, stamina, dir, FALSE) );
-        }
-        if (stimulus_type == ns_stimulus.CLASH) {
-            return ( body_state_nxt = BodyState(ns_antoc_body_state.CLASH, 0, updated_integrity, stamina, dir, FALSE) );
+        if (opponent_state_index_has_progressed == 1) {
+            if (stimulus_type == ns_stimulus.HURT) {
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.HURT, 0, updated_integrity, stamina, dir, FALSE, state_index+1, opponent_body_state_index) );
+            }
+            if (stimulus_type == ns_stimulus.KNOCKED) {
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.KNOCKED, 0, updated_integrity, stamina, dir, FALSE, state_index+1, opponent_body_state_index) );
+            }
+            if (stimulus_type == ns_stimulus.LAUNCHED) {
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.LAUNCHED, 0, updated_integrity, stamina, dir, FALSE, state_index+1, opponent_body_state_index) );
+            }
+            if (stimulus_type == ns_stimulus.CLASH) {
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.CLASH, 0, updated_integrity, stamina, dir, FALSE, state_index+1, opponent_body_state_index) );
+            }
         }
 
         // note: clash does not interrupt Antoc's attack because of sword's heaviness;
@@ -147,16 +161,16 @@ func _body_antoc {range_check_ptr}(
             if (intent == ns_antoc_action.HORI ) {
                 // return to first frame
                 if(enough_stamina == TRUE){
-                    return ( body_state_nxt = BodyState(ns_antoc_body_state.HORI, 0, integrity, updated_stamina, dir, FALSE) );
+                    return ( body_state_nxt = BodyState(ns_antoc_body_state.HORI, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
                 } else {
-                    return ( body_state_nxt = BodyState(ns_antoc_body_state.IDLE, 0, integrity, stamina, dir, TRUE) );
+                    return ( body_state_nxt = BodyState(ns_antoc_body_state.IDLE, 0, integrity, stamina, dir, TRUE, state_index+1, opponent_state_index_last_hit) );
                 }
             }
             // otherwise return to IDLE
-            return ( body_state_nxt = BodyState(ns_antoc_body_state.IDLE, 0, integrity, stamina, dir, FALSE) );
+            return ( body_state_nxt = BodyState(ns_antoc_body_state.IDLE, 0, integrity, stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
         } else {
             // increment counter
-            return ( body_state_nxt = BodyState(ns_antoc_body_state.HORI, counter + 1, integrity, stamina, dir, FALSE) );
+            return ( body_state_nxt = BodyState(ns_antoc_body_state.HORI, counter + 1, integrity, stamina, dir, FALSE, state_index, opponent_state_index_last_hit) );
         }
 
     }
@@ -167,17 +181,19 @@ func _body_antoc {range_check_ptr}(
     if (state == ns_antoc_body_state.VERT) {
 
         // body responds to stimulus first
-        if (stimulus_type == ns_stimulus.HURT) {
-            return ( body_state_nxt = BodyState(ns_antoc_body_state.HURT, 0, updated_integrity, stamina, dir, FALSE) );
-        }
-        if (stimulus_type == ns_stimulus.KNOCKED) {
-            return ( body_state_nxt = BodyState(ns_antoc_body_state.KNOCKED, 0, updated_integrity, stamina, dir, FALSE) );
-        }
-        if (stimulus_type == ns_stimulus.LAUNCHED) {
-            return ( body_state_nxt = BodyState(ns_antoc_body_state.LAUNCHED, 0, updated_integrity, stamina, dir, FALSE) );
-        }
-        if (stimulus_type == ns_stimulus.CLASH) {
-            return ( body_state_nxt = BodyState(ns_antoc_body_state.CLASH, 0, updated_integrity, stamina, dir, FALSE) );
+        if (opponent_state_index_has_progressed == 1) {
+            if (stimulus_type == ns_stimulus.HURT) {
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.HURT, 0, updated_integrity, stamina, dir, FALSE, state_index+1, opponent_body_state_index) );
+            }
+            if (stimulus_type == ns_stimulus.KNOCKED) {
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.KNOCKED, 0, updated_integrity, stamina, dir, FALSE, state_index+1, opponent_body_state_index) );
+            }
+            if (stimulus_type == ns_stimulus.LAUNCHED) {
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.LAUNCHED, 0, updated_integrity, stamina, dir, FALSE, state_index+1, opponent_body_state_index) );
+            }
+            if (stimulus_type == ns_stimulus.CLASH) {
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.CLASH, 0, updated_integrity, stamina, dir, FALSE, state_index+1, opponent_body_state_index) );
+            }
         }
 
         // note: clash does not interrupt Antoc's attack because of sword's heaviness;
@@ -188,7 +204,7 @@ func _body_antoc {range_check_ptr}(
         if (intent == ns_antoc_action.HORI) {
             if ( (counter-7) * (counter-8) * (counter-9) == 0 ) {
                 if(enough_stamina == TRUE) {
-                    return ( body_state_nxt = BodyState(ns_antoc_body_state.HORI, 0, integrity, updated_stamina, dir, FALSE) );
+                    return ( body_state_nxt = BodyState(ns_antoc_body_state.HORI, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
                 }
             }
         }
@@ -198,20 +214,20 @@ func _body_antoc {range_check_ptr}(
             if (intent == ns_antoc_action.VERT) {
                 // return to first frame
                 if(enough_stamina == TRUE){
-                    return ( body_state_nxt = BodyState(ns_antoc_body_state.VERT, 0, integrity, updated_stamina, dir, FALSE) );
+                    return ( body_state_nxt = BodyState(ns_antoc_body_state.VERT, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
                 } else {
-                    return ( body_state_nxt = BodyState(ns_antoc_body_state.IDLE, 0, integrity, stamina, dir, TRUE) );
+                    return ( body_state_nxt = BodyState(ns_antoc_body_state.IDLE, 0, integrity, stamina, dir, TRUE, state_index+1, opponent_state_index_last_hit) );
                 }
             }
             // otherwise return to IDLE
-            return ( body_state_nxt = BodyState(ns_antoc_body_state.IDLE, 0, integrity, stamina, dir, FALSE) );
+            return ( body_state_nxt = BodyState(ns_antoc_body_state.IDLE, 0, integrity, stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
         } else {
             // If Antoc is too fatigued to perform HORI then and we are not in last frame then signal fatigue and increment counter
             if (intent == ns_antoc_action.HORI) {
-                return ( body_state_nxt = BodyState(ns_antoc_body_state.VERT, counter + 1, integrity, stamina, dir, TRUE) );
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.VERT, counter + 1, integrity, stamina, dir, TRUE, state_index, opponent_state_index_last_hit) );
             }
             // increment counter
-            return ( body_state_nxt = BodyState(ns_antoc_body_state.VERT, counter + 1, integrity, stamina, dir, FALSE) );
+            return ( body_state_nxt = BodyState(ns_antoc_body_state.VERT, counter + 1, integrity, stamina, dir, FALSE, state_index, opponent_state_index_last_hit) );
         }
 
     }
@@ -222,38 +238,40 @@ func _body_antoc {range_check_ptr}(
     if (state == ns_antoc_body_state.BLOCK) {
 
         // body responds to stimulus first
-        if (stimulus_type == ns_stimulus.HURT) {
-            return ( body_state_nxt = BodyState(ns_antoc_body_state.HURT, 0, updated_integrity, stamina, dir, FALSE) );
-        }
-        if (stimulus_type == ns_stimulus.KNOCKED) {
-            return ( body_state_nxt = BodyState(ns_antoc_body_state.KNOCKED, 0, updated_integrity, stamina, dir, FALSE) );
-        }
-        if (stimulus_type == ns_stimulus.LAUNCHED) {
-            return ( body_state_nxt = BodyState(ns_antoc_body_state.LAUNCHED, 0, updated_integrity, stamina, dir, FALSE) );
+        if (opponent_state_index_has_progressed == 1) {
+            if (stimulus_type == ns_stimulus.HURT) {
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.HURT, 0, updated_integrity, stamina, dir, FALSE, state_index+1, opponent_body_state_index) );
+            }
+            if (stimulus_type == ns_stimulus.KNOCKED) {
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.KNOCKED, 0, updated_integrity, stamina, dir, FALSE, state_index+1, opponent_body_state_index) );
+            }
+            if (stimulus_type == ns_stimulus.LAUNCHED) {
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.LAUNCHED, 0, updated_integrity, stamina, dir, FALSE, state_index+1, opponent_body_state_index) );
+            }
         }
 
         // body responds to intent
         if(enough_stamina == TRUE){
             // cancel-able into STEP FORWARD - let's see what happens
             if (intent == ns_antoc_action.STEP_FORWARD) {
-                return ( body_state_nxt = BodyState(ns_antoc_body_state.STEP_FORWARD, 0, integrity, updated_stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.STEP_FORWARD, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
 
             // if intent remains BLOCK
             if (intent == ns_antoc_action.BLOCK) {
                 if (counter == 2) {
                     // if counter reaches active frame (3rd frame; counter == 2) => stay in active frame
-                    return ( body_state_nxt = BodyState(ns_antoc_body_state.BLOCK, counter, integrity, updated_stamina, dir, FALSE) );
+                    return ( body_state_nxt = BodyState(ns_antoc_body_state.BLOCK, counter, integrity, updated_stamina, dir, FALSE, state_index, opponent_state_index_last_hit) );
                 } else {
                     // else increment counter
-                    return ( body_state_nxt = BodyState(ns_antoc_body_state.BLOCK, counter + 1, integrity, updated_stamina, dir, FALSE) );
+                    return ( body_state_nxt = BodyState(ns_antoc_body_state.BLOCK, counter + 1, integrity, updated_stamina, dir, FALSE, state_index, opponent_state_index_last_hit) );
                 }
             }
         }
 
         // otherwise return to IDLE
         let (updated_stamina, _) = calculate_stamina_change(stamina, ns_antoc_action.BLOCK, ns_stamina.MAX_STAMINA, ns_character_type.ANTOC);
-        return ( body_state_nxt = BodyState(ns_antoc_body_state.IDLE, 0, integrity, updated_stamina, dir, FALSE) );
+        return ( body_state_nxt = BodyState(ns_antoc_body_state.IDLE, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
     }
 
     //
@@ -263,23 +281,25 @@ func _body_antoc {range_check_ptr}(
     if (state == ns_antoc_body_state.HURT) {
 
         // interruptible by stimulus
-        if (stimulus_type == ns_stimulus.HURT) {
-            return ( body_state_nxt = BodyState(ns_antoc_body_state.HURT, 0, updated_integrity, stamina, dir, FALSE) );
-        }
-        if (stimulus_type == ns_stimulus.KNOCKED) {
-            return ( body_state_nxt = BodyState(ns_antoc_body_state.KNOCKED, 0, updated_integrity, stamina, dir, FALSE) );
-        }
-        if (stimulus_type == ns_stimulus.LAUNCHED) {
-            return ( body_state_nxt = BodyState(ns_antoc_body_state.LAUNCHED, 0, updated_integrity, stamina, dir, FALSE) );
+        if (opponent_state_index_has_progressed == 1) {
+            if (stimulus_type == ns_stimulus.HURT) {
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.HURT, 0, updated_integrity, stamina, dir, FALSE, state_index+1, opponent_body_state_index) );
+            }
+            if (stimulus_type == ns_stimulus.KNOCKED) {
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.KNOCKED, 0, updated_integrity, stamina, dir, FALSE, state_index+1, opponent_body_state_index) );
+            }
+            if (stimulus_type == ns_stimulus.LAUNCHED) {
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.LAUNCHED, 0, updated_integrity, stamina, dir, FALSE, state_index+1, opponent_body_state_index) );
+            }
         }
 
         // if counter is full => return to IDLE
         if (counter == ns_antoc_body_state_duration.HURT - 1) {
-            return ( body_state_nxt = BodyState(ns_antoc_body_state.IDLE, 0, integrity, stamina, dir, FALSE) );
+            return ( body_state_nxt = BodyState(ns_antoc_body_state.IDLE, 0, integrity, stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
         }
 
         // else stay in HURT and increment counter
-        return ( body_state_nxt = BodyState(ns_antoc_body_state.HURT, counter + 1, integrity, stamina, dir, FALSE) );
+        return ( body_state_nxt = BodyState(ns_antoc_body_state.HURT, counter + 1, integrity, stamina, dir, FALSE, state_index, opponent_state_index_last_hit) );
     }
 
     //
@@ -289,28 +309,30 @@ func _body_antoc {range_check_ptr}(
     if (state == ns_antoc_body_state.KNOCKED) {
 
         // interruptible by stimulus
-        if (stimulus_type == ns_stimulus.HURT) {
-            return ( body_state_nxt = BodyState(ns_antoc_body_state.HURT, 0, updated_integrity, stamina, dir, FALSE) );
-        }
-        if (stimulus_type == ns_stimulus.KNOCKED) {
-            return ( body_state_nxt = BodyState(ns_antoc_body_state.KNOCKED, 0, updated_integrity, stamina, dir, FALSE) );
-        }
-        if (stimulus_type == ns_stimulus.LAUNCHED) {
-            return ( body_state_nxt = BodyState(ns_antoc_body_state.LAUNCHED, 0, updated_integrity, stamina, dir, FALSE) );
+        if (opponent_state_index_has_progressed == 1) {
+            if (stimulus_type == ns_stimulus.HURT) {
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.HURT, 0, updated_integrity, stamina, dir, FALSE, state_index+1, opponent_body_state_index) );
+            }
+            if (stimulus_type == ns_stimulus.KNOCKED) {
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.KNOCKED, 0, updated_integrity, stamina, dir, FALSE, state_index+1, opponent_body_state_index) );
+            }
+            if (stimulus_type == ns_stimulus.LAUNCHED) {
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.LAUNCHED, 0, updated_integrity, stamina, dir, FALSE, state_index+1, opponent_body_state_index) );
+            }
         }
 
         // if counter is full => return to Idle
         if (counter == ns_antoc_body_state_duration.KNOCKED - 1) {
-            return ( body_state_nxt = BodyState(ns_antoc_body_state.IDLE, 0, integrity, stamina, dir, FALSE) );
+            return ( body_state_nxt = BodyState(ns_antoc_body_state.IDLE, 0, integrity, stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
         }
 
         // if reach counter==6 and still in air => remain in counter==6
         if (counter == 6 and stimulus_type != ns_stimulus.GROUND) {
-            return ( body_state_nxt = BodyState(ns_antoc_body_state.KNOCKED, counter, integrity, stamina, dir, FALSE) );
+            return ( body_state_nxt = BodyState(ns_antoc_body_state.KNOCKED, counter, integrity, stamina, dir, FALSE, state_index, opponent_state_index_last_hit) );
         }
 
         // else stay in KNOCKED and increment counter
-        return ( body_state_nxt = BodyState(ns_antoc_body_state.KNOCKED, counter + 1, integrity, stamina, dir, FALSE) );
+        return ( body_state_nxt = BodyState(ns_antoc_body_state.KNOCKED, counter + 1, integrity, stamina, dir, FALSE, state_index, opponent_state_index_last_hit) );
     }
 
     //
@@ -319,67 +341,69 @@ func _body_antoc {range_check_ptr}(
     if (state == ns_antoc_body_state.MOVE_FORWARD) {
 
         // interruptible by stimulus
-        if (stimulus_type == ns_stimulus.HURT) {
-            return ( body_state_nxt = BodyState(ns_antoc_body_state.HURT, 0, updated_integrity, stamina, dir, FALSE) );
-        }
-        if (stimulus_type == ns_stimulus.KNOCKED) {
-            return ( body_state_nxt = BodyState(ns_antoc_body_state.KNOCKED, 0, updated_integrity, stamina, dir, FALSE) );
-        }
-        if (stimulus_type == ns_stimulus.LAUNCHED) {
-            return ( body_state_nxt = BodyState(ns_antoc_body_state.LAUNCHED, 0, updated_integrity, stamina, dir, FALSE) );
+        if (opponent_state_index_has_progressed == 1) {
+            if (stimulus_type == ns_stimulus.HURT) {
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.HURT, 0, updated_integrity, stamina, dir, FALSE, state_index+1, opponent_body_state_index) );
+            }
+            if (stimulus_type == ns_stimulus.KNOCKED) {
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.KNOCKED, 0, updated_integrity, stamina, dir, FALSE, state_index+1, opponent_body_state_index) );
+            }
+            if (stimulus_type == ns_stimulus.LAUNCHED) {
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.LAUNCHED, 0, updated_integrity, stamina, dir, FALSE, state_index+1, opponent_body_state_index) );
+            }
         }
 
         // interruptible by agent intent (locomotive action has lowest priority)
         if (intent == ns_antoc_action.TAUNT) {
-            return ( body_state_nxt = BodyState(ns_antoc_body_state.TAUNT_PARIS23, 0, integrity, updated_stamina, dir, FALSE) );
+            return ( body_state_nxt = BodyState(ns_antoc_body_state.TAUNT_PARIS23, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
         }
         if (intent == ns_antoc_action.BLOCK) {
-            return ( body_state_nxt = BodyState(ns_antoc_body_state.BLOCK, 0, integrity, updated_stamina, dir, FALSE) );
+            return ( body_state_nxt = BodyState(ns_antoc_body_state.BLOCK, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
         }
         if(enough_stamina == TRUE){
             if (intent == ns_antoc_action.HORI) {
-                return ( body_state_nxt = BodyState(ns_antoc_body_state.HORI, 0, integrity, updated_stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.HORI, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
             if (intent == ns_antoc_action.VERT) {
-                return ( body_state_nxt = BodyState(ns_antoc_body_state.VERT, 0, integrity, updated_stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.VERT, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
             if (intent == ns_antoc_action.LOW_KICK) {
-                return ( body_state_nxt = BodyState(ns_antoc_body_state.LOW_KICK, 0, integrity, updated_stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.LOW_KICK, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
             if (intent == ns_antoc_action.DASH_FORWARD) {
-                    return ( body_state_nxt = BodyState(ns_antoc_body_state.DASH_FORWARD, 0, integrity, updated_stamina, dir, FALSE) );
+                    return ( body_state_nxt = BodyState(ns_antoc_body_state.DASH_FORWARD, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
             if (intent == ns_antoc_action.DASH_BACKWARD) {
-                    return ( body_state_nxt = BodyState(ns_antoc_body_state.DASH_BACKWARD, 0, integrity, updated_stamina, dir, FALSE) );
+                    return ( body_state_nxt = BodyState(ns_antoc_body_state.DASH_BACKWARD, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
             if (intent == ns_antoc_action.JUMP) {
-                return ( body_state_nxt = BodyState(ns_antoc_body_state.JUMP, 0, integrity, updated_stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.JUMP, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
             if (intent == ns_antoc_action.STEP_FORWARD) {
-                return ( body_state_nxt = BodyState(ns_antoc_body_state.STEP_FORWARD, 0, integrity, updated_stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.STEP_FORWARD, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
             if (intent == ns_antoc_action.CYCLONE) {
-                return ( body_state_nxt = BodyState(ns_antoc_body_state.CYCLONE, 0, integrity, updated_stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.CYCLONE, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
         }
 
         // continue moving forward
         if (intent == ns_antoc_action.MOVE_FORWARD) {
             if (counter == ns_antoc_body_state_duration.MOVE_FORWARD - 1) {
-                return ( body_state_nxt = BodyState(ns_antoc_body_state.MOVE_FORWARD, 0, integrity, updated_stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.MOVE_FORWARD, 0, integrity, updated_stamina, dir, FALSE, state_index, opponent_state_index_last_hit) );
             } else {
-                return ( body_state_nxt = BodyState(ns_antoc_body_state.MOVE_FORWARD, counter + 1, integrity, updated_stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.MOVE_FORWARD, counter + 1, integrity, updated_stamina, dir, FALSE, state_index, opponent_state_index_last_hit) );
             }
         }
 
         // able to reverse direction immediately
         if (intent == ns_antoc_action.MOVE_BACKWARD) {
-            return ( body_state_nxt = BodyState(ns_antoc_body_state.MOVE_BACKWARD, 0, integrity, updated_stamina, dir, FALSE) );
+            return ( body_state_nxt = BodyState(ns_antoc_body_state.MOVE_BACKWARD, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
         }
 
         // otherwise return to idle
         let (updated_stamina, _) = calculate_stamina_change(stamina, ns_antoc_action.MOVE_FORWARD, ns_stamina.MAX_STAMINA, ns_character_type.ANTOC);
-        return ( body_state_nxt = BodyState(ns_antoc_body_state.IDLE, 0, integrity, updated_stamina, dir, is_fatigued) );
+        return ( body_state_nxt = BodyState(ns_antoc_body_state.IDLE, 0, integrity, updated_stamina, dir, is_fatigued, state_index+1, opponent_state_index_last_hit) );
     }
 
     //
@@ -388,67 +412,69 @@ func _body_antoc {range_check_ptr}(
     if (state == ns_antoc_body_state.MOVE_BACKWARD) {
 
         // interruptible by stimulus
-        if (stimulus_type == ns_stimulus.HURT) {
-            return ( body_state_nxt = BodyState(ns_antoc_body_state.HURT, 0, updated_integrity, stamina, dir, FALSE) );
-        }
-        if (stimulus_type == ns_stimulus.KNOCKED) {
-            return ( body_state_nxt = BodyState(ns_antoc_body_state.KNOCKED, 0, updated_integrity, stamina, dir, FALSE) );
-        }
-        if (stimulus_type == ns_stimulus.LAUNCHED) {
-            return ( body_state_nxt = BodyState(ns_antoc_body_state.LAUNCHED, 0, updated_integrity, stamina, dir, FALSE) );
+        if (opponent_state_index_has_progressed == 1) {
+            if (stimulus_type == ns_stimulus.HURT) {
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.HURT, 0, updated_integrity, stamina, dir, FALSE, state_index+1, opponent_body_state_index) );
+            }
+            if (stimulus_type == ns_stimulus.KNOCKED) {
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.KNOCKED, 0, updated_integrity, stamina, dir, FALSE, state_index+1, opponent_body_state_index) );
+            }
+            if (stimulus_type == ns_stimulus.LAUNCHED) {
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.LAUNCHED, 0, updated_integrity, stamina, dir, FALSE, state_index+1, opponent_body_state_index) );
+            }
         }
 
         // interruptible by agent intent (locomotive action has lowest priority)
         if (intent == ns_antoc_action.TAUNT) {
-            return ( body_state_nxt = BodyState(ns_antoc_body_state.TAUNT_PARIS23, 0, integrity, updated_stamina, dir, FALSE) );
+            return ( body_state_nxt = BodyState(ns_antoc_body_state.TAUNT_PARIS23, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
         }
         if (intent == ns_antoc_action.BLOCK) {
-            return ( body_state_nxt = BodyState(ns_antoc_body_state.BLOCK, 0, integrity, updated_stamina, dir, FALSE) );
+            return ( body_state_nxt = BodyState(ns_antoc_body_state.BLOCK, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
         }
         if (enough_stamina == TRUE) {
             if (intent == ns_antoc_action.HORI) {
-                return ( body_state_nxt = BodyState(ns_antoc_body_state.HORI, 0, integrity, updated_stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.HORI, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
             if (intent == ns_antoc_action.VERT) {
-                return ( body_state_nxt = BodyState(ns_antoc_body_state.VERT, 0, integrity, updated_stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.VERT, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
             if (intent == ns_antoc_action.LOW_KICK) {
-                return ( body_state_nxt = BodyState(ns_antoc_body_state.LOW_KICK, 0, integrity, updated_stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.LOW_KICK, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
             if (intent == ns_antoc_action.DASH_FORWARD) {
-                return ( body_state_nxt = BodyState(ns_antoc_body_state.DASH_FORWARD, 0, integrity, updated_stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.DASH_FORWARD, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
             if (intent == ns_antoc_action.DASH_BACKWARD) {
-                return ( body_state_nxt = BodyState(ns_antoc_body_state.DASH_BACKWARD, 0, integrity, updated_stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.DASH_BACKWARD, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
             if (intent == ns_antoc_action.JUMP) {
-                return ( body_state_nxt = BodyState(ns_antoc_body_state.JUMP, 0, integrity, updated_stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.JUMP, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
             if (intent == ns_antoc_action.STEP_FORWARD) {
-                return ( body_state_nxt = BodyState(ns_antoc_body_state.STEP_FORWARD, 0, integrity, updated_stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.STEP_FORWARD, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
             if (intent == ns_antoc_action.CYCLONE) {
-                return ( body_state_nxt = BodyState(ns_antoc_body_state.CYCLONE, 0, integrity, updated_stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.CYCLONE, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
         }
 
         // continue moving forward
         if (intent == ns_antoc_action.MOVE_BACKWARD) {
             if (counter == ns_antoc_body_state_duration.MOVE_BACKWARD - 1) {
-                return ( body_state_nxt = BodyState(ns_antoc_body_state.MOVE_BACKWARD, 0, integrity, updated_stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.MOVE_BACKWARD, 0, integrity, updated_stamina, dir, FALSE, state_index, opponent_state_index_last_hit) );
             } else {
-                return ( body_state_nxt = BodyState(ns_antoc_body_state.MOVE_BACKWARD, counter + 1, integrity, updated_stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.MOVE_BACKWARD, counter + 1, integrity, updated_stamina, dir, FALSE, state_index, opponent_state_index_last_hit) );
             }
         }
 
         // able to reverse direction immediately
         if (intent == ns_antoc_action.MOVE_FORWARD) {
-            return ( body_state_nxt = BodyState(ns_antoc_body_state.MOVE_FORWARD, 0, integrity, updated_stamina, dir, FALSE) );
+            return ( body_state_nxt = BodyState(ns_antoc_body_state.MOVE_FORWARD, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
         }
 
         // otherwise return to idle
         let (updated_stamina, _) = calculate_stamina_change(stamina, ns_antoc_action.MOVE_BACKWARD, ns_stamina.MAX_STAMINA, ns_character_type.ANTOC);
-        return ( body_state_nxt = BodyState(ns_antoc_body_state.IDLE, 0, integrity, updated_stamina, dir, is_fatigued) );
+        return ( body_state_nxt = BodyState(ns_antoc_body_state.IDLE, 0, integrity, updated_stamina, dir, is_fatigued, state_index+1, opponent_state_index_last_hit) );
     }
 
     //
@@ -461,14 +487,14 @@ func _body_antoc {range_check_ptr}(
         // can cancel dash into JUMP's counter==0 while grounded
         if (enough_stamina == TRUE and stimulus_type == ns_stimulus.GROUND) {
             if (intent == ns_antoc_action.JUMP) {
-                return ( body_state_nxt = BodyState(ns_antoc_body_state.JUMP, 0, integrity, updated_stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.JUMP, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
         }
 
         // can cancel dash into DROP_SLASH's counter==2 while not grounded
         if (enough_stamina == TRUE and stimulus_type != ns_stimulus.GROUND) {
             if (intent == ns_antoc_action.VERT) {
-                return ( body_state_nxt = BodyState(ns_antoc_body_state.DROP_SLASH, 2, integrity, updated_stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.DROP_SLASH, 2, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
         }
 
@@ -476,19 +502,19 @@ func _body_antoc {range_check_ptr}(
         if (counter == ns_antoc_body_state_duration.DASH_FORWARD - 1) {
             // if not grounded => return to JUMP's counter==4
             if (stimulus_type != ns_stimulus.GROUND) {
-                return ( body_state_nxt = BodyState(ns_antoc_body_state.JUMP, 4, integrity, updated_stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.JUMP, 4, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
 
             // continue the dashing if not interrupted by an attack
             // note: not cancellable into attack because of sword's heaviness
             // note: not able to reverse to the opposite dash immediately
             if(enough_stamina == TRUE and intent == ns_antoc_body_state.DASH_FORWARD) {
-                return ( body_state_nxt = BodyState(ns_antoc_body_state.DASH_FORWARD, 0, integrity, updated_stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.DASH_FORWARD, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
-            return ( body_state_nxt = BodyState(ns_antoc_body_state.IDLE, 0, integrity, stamina, dir, TRUE) );
+            return ( body_state_nxt = BodyState(ns_antoc_body_state.IDLE, 0, integrity, stamina, dir, TRUE, state_index+1, opponent_state_index_last_hit) );
         }
         // increment counter
-        return ( body_state_nxt = BodyState(ns_antoc_body_state.DASH_FORWARD, counter + 1, integrity, stamina, dir, FALSE) );
+        return ( body_state_nxt = BodyState(ns_antoc_body_state.DASH_FORWARD, counter + 1, integrity, stamina, dir, FALSE, state_index, opponent_state_index_last_hit) );
     }
 
     //
@@ -499,14 +525,14 @@ func _body_antoc {range_check_ptr}(
         // can cancel dash into JUMP's counter==0 while grounded
         if (enough_stamina == TRUE and stimulus_type == ns_stimulus.GROUND) {
             if (intent == ns_antoc_action.JUMP) {
-                return ( body_state_nxt = BodyState(ns_antoc_body_state.JUMP, 0, integrity, updated_stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.JUMP, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
         }
 
         // can cancel dash into DROP_SLASH's counter==2 while not grounded
         if (enough_stamina == TRUE and stimulus_type != ns_stimulus.GROUND) {
             if (intent == ns_antoc_action.VERT) {
-                return ( body_state_nxt = BodyState(ns_antoc_body_state.DROP_SLASH, 2, integrity, updated_stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.DROP_SLASH, 2, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
         }
 
@@ -514,19 +540,19 @@ func _body_antoc {range_check_ptr}(
         if (counter == ns_antoc_body_state_duration.DASH_BACKWARD - 1) {
             // if not grounded => return to JUMP's counter==4
             if (stimulus_type != ns_stimulus.GROUND) {
-                return ( body_state_nxt = BodyState(ns_antoc_body_state.JUMP, 4, integrity, updated_stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.JUMP, 4, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
 
             // continue the dashing if not interrupted by an attack
             // note: not cancellable into attack because of sword's heaviness
             // note: not able to reverse to the opposite dash immediately
             if(enough_stamina == TRUE and intent == ns_antoc_body_state.DASH_BACKWARD) {
-                return ( body_state_nxt = BodyState(ns_antoc_body_state.DASH_BACKWARD, 0, integrity, updated_stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.DASH_BACKWARD, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
-            return ( body_state_nxt = BodyState(ns_antoc_body_state.IDLE, 0, integrity, stamina, dir, TRUE) );
+            return ( body_state_nxt = BodyState(ns_antoc_body_state.IDLE, 0, integrity, stamina, dir, TRUE, state_index+1, opponent_state_index_last_hit) );
         }
         // increment counter
-        return ( body_state_nxt = BodyState(ns_antoc_body_state.DASH_BACKWARD, counter + 1, integrity, stamina, dir, FALSE) );
+        return ( body_state_nxt = BodyState(ns_antoc_body_state.DASH_BACKWARD, counter + 1, integrity, stamina, dir, FALSE, state_index, opponent_state_index_last_hit) );
     }
 
     //
@@ -536,23 +562,25 @@ func _body_antoc {range_check_ptr}(
     if (state == ns_antoc_body_state.CLASH) {
 
         // interruptible by stimulus
-        if (stimulus_type == ns_stimulus.HURT) {
-            return ( body_state_nxt = BodyState(ns_antoc_body_state.HURT, 0, updated_integrity, stamina, dir, FALSE) );
-        }
-        if (stimulus_type == ns_stimulus.KNOCKED) {
-            return ( body_state_nxt = BodyState(ns_antoc_body_state.KNOCKED, 0, updated_integrity, stamina, dir, FALSE) );
-        }
-        if (stimulus_type == ns_stimulus.LAUNCHED) {
-            return ( body_state_nxt = BodyState(ns_antoc_body_state.LAUNCHED, 0, updated_integrity, stamina, dir, FALSE) );
+        if (opponent_state_index_has_progressed == 1) {
+            if (stimulus_type == ns_stimulus.HURT) {
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.HURT, 0, updated_integrity, stamina, dir, FALSE, state_index+1, opponent_body_state_index) );
+            }
+            if (stimulus_type == ns_stimulus.KNOCKED) {
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.KNOCKED, 0, updated_integrity, stamina, dir, FALSE, state_index+1, opponent_body_state_index) );
+            }
+            if (stimulus_type == ns_stimulus.LAUNCHED) {
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.LAUNCHED, 0, updated_integrity, stamina, dir, FALSE, state_index+1, opponent_body_state_index) );
+            }
         }
 
         // if counter is full => return to IDLE
         if (counter == ns_antoc_body_state_duration.CLASH - 1) {
-            return ( body_state_nxt = BodyState(ns_antoc_body_state.IDLE, 0, integrity, stamina, dir, FALSE) );
+            return ( body_state_nxt = BodyState(ns_antoc_body_state.IDLE, 0, integrity, stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
         }
 
         // else stay in CLASH and increment counter
-        return ( body_state_nxt = BodyState(ns_antoc_body_state.CLASH, counter + 1, integrity, stamina, dir, FALSE) );
+        return ( body_state_nxt = BodyState(ns_antoc_body_state.CLASH, counter + 1, integrity, stamina, dir, FALSE, state_index, opponent_state_index_last_hit) );
     }
 
     //
@@ -561,53 +589,55 @@ func _body_antoc {range_check_ptr}(
     //
     if ((state-ns_antoc_body_state.JUMP)*(state-ns_antoc_body_state.JUMP_MOVE_FORWARD)*(state-ns_antoc_body_state.JUMP_MOVE_BACKWARD) == 0) {
 
-        // can be knocked
-        if (stimulus_type == ns_stimulus.KNOCKED) {
-            return ( body_state_nxt = BodyState(ns_antoc_body_state.KNOCKED, 0, updated_integrity, stamina, dir, FALSE) );
-        }
-        // can be launched
-        if (stimulus_type == ns_stimulus.LAUNCHED) {
-            return ( body_state_nxt = BodyState(ns_antoc_body_state.LAUNCHED, 0, updated_integrity, stamina, dir, FALSE) );
+        if (opponent_state_index_has_progressed == 1) {
+            // can be knocked
+            if (stimulus_type == ns_stimulus.KNOCKED) {
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.KNOCKED, 0, updated_integrity, stamina, dir, FALSE, state_index+1, opponent_body_state_index) );
+            }
+            // can be launched
+            if (stimulus_type == ns_stimulus.LAUNCHED) {
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.LAUNCHED, 0, updated_integrity, stamina, dir, FALSE, state_index+1, opponent_body_state_index) );
+            }
         }
 
         // VERT during counter==1/2/3 can cancel into air attack (drop slash)
         if (intent == ns_antoc_action.VERT and (counter-1)*(counter-2)*(counter-3) == 0) {
-            return ( body_state_nxt = BodyState(ns_antoc_body_state.DROP_SLASH, 0, integrity, stamina, dir, FALSE) );
+            return ( body_state_nxt = BodyState(ns_antoc_body_state.DROP_SLASH, 0, integrity, stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
         }
 
         // DASH FORWARD/BACKWARD during counter!=0/4/5 (ie counter==1/2/3) becomes dash forward/backward's counter==0
         // note: this is to prevent multiple air dashes during the same jump
         if ((counter-1) * (counter-2) * (counter-3) == 0) {
             if (intent == ns_antoc_action.DASH_FORWARD) {
-                return ( body_state_nxt = BodyState(ns_antoc_body_state.DASH_FORWARD, 0, integrity, updated_stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.DASH_FORWARD, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
             if (intent == ns_antoc_action.DASH_BACKWARD) {
-                return ( body_state_nxt = BodyState(ns_antoc_body_state.DASH_BACKWARD, 0, integrity, updated_stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.DASH_BACKWARD, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
         }
 
         // if counter is full => return to IDLE
         if (counter == ns_antoc_body_state_duration.JUMP - 1) {
-            return ( body_state_nxt = BodyState(ns_antoc_body_state.IDLE, 0, integrity, stamina, dir, FALSE) );
+            return ( body_state_nxt = BodyState(ns_antoc_body_state.IDLE, 0, integrity, stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
         }
 
         // if reach counter==4 and still in air => remain in counter==4
         if (counter == 4 and stimulus_type != ns_stimulus.GROUND) {
-            return ( body_state_nxt = BodyState(ns_antoc_body_state.JUMP, counter, integrity, stamina, dir, FALSE) );
+            return ( body_state_nxt = BodyState(ns_antoc_body_state.JUMP, counter, integrity, stamina, dir, FALSE, state_index, opponent_state_index_last_hit) );
         }
 
         // MOVE FORWARD/BACKWARD during counter!=0/5 (counter == 1/2/3/4) becomes JUMP_MOVE_FORWARD/BACKWARD's counter+1
         if ((counter-1)*(counter-2)*(counter-3)*(counter-4) == 0) {
             if (intent == ns_antoc_action.MOVE_FORWARD) {
-                return ( body_state_nxt = BodyState(ns_antoc_body_state.JUMP_MOVE_FORWARD, counter+1, integrity, updated_stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.JUMP_MOVE_FORWARD, counter+1, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
             if (intent == ns_antoc_action.MOVE_BACKWARD) {
-                return ( body_state_nxt = BodyState(ns_antoc_body_state.JUMP_MOVE_BACKWARD, counter+1, integrity, updated_stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.JUMP_MOVE_BACKWARD, counter+1, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
         }
 
         // else stay in JUMP and increment counter
-        return ( body_state_nxt = BodyState(ns_antoc_body_state.JUMP, counter + 1, integrity, stamina, dir, FALSE) );
+        return ( body_state_nxt = BodyState(ns_antoc_body_state.JUMP, counter + 1, integrity, stamina, dir, FALSE, state_index, opponent_state_index_last_hit) );
     }
 
     //
@@ -618,33 +648,35 @@ func _body_antoc {range_check_ptr}(
     if (state == ns_antoc_body_state.STEP_FORWARD) {
 
         // interruptible by stimulus
-        if (stimulus_type == ns_stimulus.HURT) {
-            return ( body_state_nxt = BodyState(ns_antoc_body_state.HURT, 0, updated_integrity, stamina, dir, FALSE) );
-        }
-        if (stimulus_type == ns_stimulus.KNOCKED) {
-            return ( body_state_nxt = BodyState(ns_antoc_body_state.KNOCKED, 0, updated_integrity, stamina, dir, FALSE) );
-        }
-        if (stimulus_type == ns_stimulus.LAUNCHED) {
-            return ( body_state_nxt = BodyState(ns_antoc_body_state.LAUNCHED, 0, updated_integrity, stamina, dir, FALSE) );
+        if (opponent_state_index_has_progressed == 1) {
+            if (stimulus_type == ns_stimulus.HURT) {
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.HURT, 0, updated_integrity, stamina, dir, FALSE, state_index+1, opponent_body_state_index) );
+            }
+            if (stimulus_type == ns_stimulus.KNOCKED) {
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.KNOCKED, 0, updated_integrity, stamina, dir, FALSE, state_index+1, opponent_body_state_index) );
+            }
+            if (stimulus_type == ns_stimulus.LAUNCHED) {
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.LAUNCHED, 0, updated_integrity, stamina, dir, FALSE, state_index+1, opponent_body_state_index) );
+            }
         }
 
         // if having enough stamina => fast cancel into VERT's active frame -1 (counter==2) or LOW_KICK's active frame -1 (counter==2)
         if (enough_stamina == TRUE) {
             if (intent == ns_antoc_action.VERT) {
-                return ( body_state_nxt = BodyState(ns_antoc_body_state.VERT, 2, integrity, updated_stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.VERT, 2, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
             if (intent == ns_antoc_action.LOW_KICK) {
-                return ( body_state_nxt = BodyState(ns_antoc_body_state.LOW_KICK, 2, integrity, updated_stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.LOW_KICK, 2, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
         }
 
         // if counter is full => return to IDLE
         if (counter == ns_antoc_body_state_duration.STEP_FORWARD - 1) {
-            return ( body_state_nxt = BodyState(ns_antoc_body_state.IDLE, 0, integrity, stamina, dir, FALSE) );
+            return ( body_state_nxt = BodyState(ns_antoc_body_state.IDLE, 0, integrity, stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
         }
 
         // else stay in STEP_FORWARD and increment counter
-        return ( body_state_nxt = BodyState(ns_antoc_body_state.STEP_FORWARD, counter + 1, integrity, stamina, dir, FALSE) );
+        return ( body_state_nxt = BodyState(ns_antoc_body_state.STEP_FORWARD, counter + 1, integrity, stamina, dir, FALSE, state_index, opponent_state_index_last_hit) );
     }
 
     //
@@ -653,27 +685,29 @@ func _body_antoc {range_check_ptr}(
     if (state == ns_antoc_body_state.LOW_KICK) {
 
         // body responds to stimulus first
-        if (stimulus_type == ns_stimulus.HURT) {
-            return ( body_state_nxt = BodyState(ns_antoc_body_state.HURT, 0, updated_integrity, stamina, dir, FALSE) );
-        }
-        if (stimulus_type == ns_stimulus.KNOCKED) {
-            return ( body_state_nxt = BodyState(ns_antoc_body_state.KNOCKED, 0, updated_integrity, stamina, dir, FALSE) );
-        }
-        if (stimulus_type == ns_stimulus.LAUNCHED) {
-            return ( body_state_nxt = BodyState(ns_antoc_body_state.LAUNCHED, 0, updated_integrity, stamina, dir, FALSE) );
-        }
-        if (stimulus_type == ns_stimulus.CLASH) {
-            return ( body_state_nxt = BodyState(ns_antoc_body_state.CLASH, 0, updated_integrity, stamina, dir, FALSE) );
+        if (opponent_state_index_has_progressed == 1) {
+            if (stimulus_type == ns_stimulus.HURT) {
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.HURT, 0, updated_integrity, stamina, dir, FALSE, state_index+1, opponent_body_state_index) );
+            }
+            if (stimulus_type == ns_stimulus.KNOCKED) {
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.KNOCKED, 0, updated_integrity, stamina, dir, FALSE, state_index+1, opponent_body_state_index) );
+            }
+            if (stimulus_type == ns_stimulus.LAUNCHED) {
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.LAUNCHED, 0, updated_integrity, stamina, dir, FALSE, state_index+1, opponent_body_state_index) );
+            }
+            if (stimulus_type == ns_stimulus.CLASH) {
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.CLASH, 0, updated_integrity, stamina, dir, FALSE, state_index+1, opponent_body_state_index) );
+            }
         }
 
         // body responds to intent
         // LOW_KICK at recovery frame is cancellable into either STEP FORWARD or DASH BACKWARD
         if ((counter-4) * (counter-5) == 0 and enough_stamina == TRUE) {
             if (intent == ns_antoc_action.STEP_FORWARD) {
-                return ( body_state_nxt = BodyState(ns_antoc_body_state.STEP_FORWARD, 0, integrity, updated_stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.STEP_FORWARD, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
             if (intent == ns_antoc_action.DASH_BACKWARD) {
-                return ( body_state_nxt = BodyState(ns_antoc_body_state.DASH_BACKWARD, 0, integrity, updated_stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.DASH_BACKWARD, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
         }
 
@@ -681,14 +715,14 @@ func _body_antoc {range_check_ptr}(
         if (counter == ns_antoc_body_state_duration.LOW_KICK - 1) {
             if (intent == ns_antoc_action.LOW_KICK and enough_stamina == TRUE) {
                 // restart from second frame
-                return ( body_state_nxt = BodyState(ns_antoc_body_state.LOW_KICK, 2, integrity, updated_stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.LOW_KICK, 2, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
             // otherwise return to IDLE
-            return ( body_state_nxt = BodyState(ns_antoc_body_state.IDLE, 0, integrity, stamina, dir, FALSE) );
+            return ( body_state_nxt = BodyState(ns_antoc_body_state.IDLE, 0, integrity, stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
         }
 
         // otherwise increment counter
-        return ( body_state_nxt = BodyState(ns_antoc_body_state.LOW_KICK, counter + 1, integrity, stamina, dir, FALSE) );
+        return ( body_state_nxt = BodyState(ns_antoc_body_state.LOW_KICK, counter + 1, integrity, stamina, dir, FALSE, state_index, opponent_state_index_last_hit) );
 
     }
 
@@ -698,27 +732,29 @@ func _body_antoc {range_check_ptr}(
     //
     if (state == ns_antoc_body_state.LAUNCHED) {
 
-        // can be knocked
-        if (stimulus_type == ns_stimulus.KNOCKED) {
-            return ( body_state_nxt = BodyState(ns_antoc_body_state.KNOCKED, 0, updated_integrity, stamina, dir, FALSE) );
-        }
-        // can be juggled
-        if (stimulus_type == ns_stimulus.LAUNCHED) {
-            return ( body_state_nxt = BodyState(ns_antoc_body_state.LAUNCHED, 0, updated_integrity, stamina, dir, FALSE) );
+        if (opponent_state_index_has_progressed == 1) {
+            // can be knocked
+            if (stimulus_type == ns_stimulus.KNOCKED) {
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.KNOCKED, 0, updated_integrity, stamina, dir, FALSE, state_index+1, opponent_body_state_index) );
+            }
+            // can be juggled
+            if (stimulus_type == ns_stimulus.LAUNCHED) {
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.LAUNCHED, 0, updated_integrity, stamina, dir, FALSE, state_index+1, opponent_body_state_index) );
+            }
         }
 
         // if counter is full => return to IDLE
         if (counter == ns_antoc_body_state_duration.LAUNCHED - 1) {
-            return ( body_state_nxt = BodyState(ns_antoc_body_state.IDLE, 0, integrity, stamina, dir, FALSE) );
+            return ( body_state_nxt = BodyState(ns_antoc_body_state.IDLE, 0, integrity, stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
         }
 
         // if reach counter==6 and still in air => remain in counter==6
         if (counter == 6 and stimulus_type != ns_stimulus.GROUND) {
-            return ( body_state_nxt = BodyState(ns_antoc_body_state.LAUNCHED, counter, integrity, stamina, dir, FALSE) );
+            return ( body_state_nxt = BodyState(ns_antoc_body_state.LAUNCHED, counter, integrity, stamina, dir, FALSE, state_index, opponent_state_index_last_hit) );
         }
 
         // else stay in LAUNCHED and increment counter
-        return ( body_state_nxt = BodyState(ns_antoc_body_state.LAUNCHED, counter + 1, integrity, stamina, dir, FALSE) );
+        return ( body_state_nxt = BodyState(ns_antoc_body_state.LAUNCHED, counter + 1, integrity, stamina, dir, FALSE, state_index, opponent_state_index_last_hit) );
     }
 
     //
@@ -727,13 +763,15 @@ func _body_antoc {range_check_ptr}(
     //
     if (state == ns_antoc_body_state.DROP_SLASH) {
 
-        // can be knocked
-        if (stimulus_type == ns_stimulus.KNOCKED) {
-            return ( body_state_nxt = BodyState(ns_antoc_body_state.KNOCKED, 0, updated_integrity, stamina, dir, FALSE) );
-        }
-        // can be launched
-        if (stimulus_type == ns_stimulus.LAUNCHED) {
-            return ( body_state_nxt = BodyState(ns_antoc_body_state.LAUNCHED, 0, updated_integrity, stamina, dir, FALSE) );
+        if (opponent_state_index_has_progressed == 1) {
+            // can be knocked
+            if (stimulus_type == ns_stimulus.KNOCKED) {
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.KNOCKED, 0, updated_integrity, stamina, dir, FALSE, state_index+1, opponent_body_state_index) );
+            }
+            // can be launched
+            if (stimulus_type == ns_stimulus.LAUNCHED) {
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.LAUNCHED, 0, updated_integrity, stamina, dir, FALSE, state_index+1, opponent_body_state_index) );
+            }
         }
 
         // if counter is full
@@ -741,14 +779,14 @@ func _body_antoc {range_check_ptr}(
         //   otherwise return to IDLE
         if (counter == ns_antoc_body_state_duration.DROP_SLASH - 1) {
             if (stimulus_type != ns_stimulus.GROUND) {
-                return ( body_state_nxt = BodyState(ns_antoc_body_state.JUMP, 4, integrity, stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.JUMP, 4, integrity, stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             } else {
-                return ( body_state_nxt = BodyState(ns_antoc_body_state.IDLE, 0, integrity, stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.IDLE, 0, integrity, stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
         }
 
         // else stay in DROP_SLASH and increment counter
-        return ( body_state_nxt = BodyState(ns_antoc_body_state.DROP_SLASH, counter + 1, integrity, stamina, dir, FALSE) );
+        return ( body_state_nxt = BodyState(ns_antoc_body_state.DROP_SLASH, counter + 1, integrity, stamina, dir, FALSE, state_index, opponent_state_index_last_hit) );
     }
 
     //
@@ -757,84 +795,89 @@ func _body_antoc {range_check_ptr}(
     //
     if (state == ns_antoc_body_state.CYCLONE) {
 
-        if (stimulus_type == ns_stimulus.CLASH) {
-            return ( body_state_nxt = BodyState(ns_antoc_body_state.CLASH, 0, updated_integrity, stamina, dir, FALSE) );
+        if (opponent_state_index_has_progressed == 1) {
+            if (stimulus_type == ns_stimulus.CLASH) {
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.CLASH, 0, updated_integrity, stamina, dir, FALSE, state_index+1, opponent_body_state_index) );
+            }
         }
 
         // if counter is full => return to IDLE
         if (counter == ns_antoc_body_state_duration.CYCLONE - 1) {
-            return ( body_state_nxt = BodyState(ns_antoc_body_state.IDLE, 0, integrity, stamina, dir, FALSE) );
+            return ( body_state_nxt = BodyState(ns_antoc_body_state.IDLE, 0, integrity, stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
         }
 
         // else stay in CYCLONE and increment counter
-        return ( body_state_nxt = BodyState(ns_antoc_body_state.CYCLONE, counter + 1, integrity, stamina, dir, FALSE) );
+        return ( body_state_nxt = BodyState(ns_antoc_body_state.CYCLONE, counter + 1, integrity, stamina, dir, FALSE, state_index, opponent_state_index_last_hit) );
     }
 
     //
     // Taunt
     //
     if (state == ns_antoc_body_state.TAUNT_PARIS23) {
+
         // body responds to stimulus first
-        if (stimulus_type == ns_stimulus.HURT) {
-            return ( body_state_nxt = BodyState(ns_antoc_body_state.HURT, 0, updated_integrity , stamina, dir, FALSE) );
-        }
-        if (stimulus_type == ns_stimulus.KNOCKED) {
-            return ( body_state_nxt = BodyState(ns_antoc_body_state.KNOCKED, 0, updated_integrity, stamina, dir, FALSE) );
-        }
-        if (stimulus_type == ns_stimulus.LAUNCHED) {
-            return ( body_state_nxt = BodyState(ns_antoc_body_state.LAUNCHED, 0, updated_integrity, stamina, dir, FALSE) );
+        if (opponent_state_index_has_progressed == 1) {
+            if (stimulus_type == ns_stimulus.HURT) {
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.HURT, 0, updated_integrity , stamina, dir, FALSE, state_index+1, opponent_body_state_index) );
+            }
+            if (stimulus_type == ns_stimulus.KNOCKED) {
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.KNOCKED, 0, updated_integrity, stamina, dir, FALSE, state_index+1, opponent_body_state_index) );
+            }
+            if (stimulus_type == ns_stimulus.LAUNCHED) {
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.LAUNCHED, 0, updated_integrity, stamina, dir, FALSE, state_index+1, opponent_body_state_index) );
+            }
         }
 
         // body responds to intent; locomotive action has lowest priority
         if (intent == ns_antoc_action.MOVE_FORWARD) {
-            return ( body_state_nxt = BodyState(ns_antoc_body_state.MOVE_FORWARD, 0, integrity, updated_stamina, dir, FALSE) );
+            return ( body_state_nxt = BodyState(ns_antoc_body_state.MOVE_FORWARD, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
         }
         if (intent == ns_antoc_action.MOVE_BACKWARD) {
-            return ( body_state_nxt = BodyState(ns_antoc_body_state.MOVE_BACKWARD, 0, integrity, updated_stamina, dir, FALSE) );
+            return ( body_state_nxt = BodyState(ns_antoc_body_state.MOVE_BACKWARD, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
         }
         if (intent == ns_antoc_action.BLOCK) {
-            return ( body_state_nxt = BodyState(ns_antoc_body_state.BLOCK, 0, integrity, updated_stamina, dir, FALSE) );
+            return ( body_state_nxt = BodyState(ns_antoc_body_state.BLOCK, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
         }
         if(enough_stamina == TRUE){
             if (intent == ns_antoc_action.HORI) {
-                return ( body_state_nxt = BodyState(ns_antoc_body_state.HORI, 0, integrity, updated_stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.HORI, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
             if (intent == ns_antoc_action.VERT) {
-                return ( body_state_nxt = BodyState(ns_antoc_body_state.VERT, 0, integrity, updated_stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.VERT, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
             if (intent == ns_antoc_action.LOW_KICK) {
-                return ( body_state_nxt = BodyState(ns_antoc_body_state.LOW_KICK, 0, integrity, updated_stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.LOW_KICK, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
             if (intent == ns_antoc_action.DASH_FORWARD) {
-                return ( body_state_nxt = BodyState(ns_antoc_body_state.DASH_FORWARD, 0, integrity, updated_stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.DASH_FORWARD, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
             if (intent == ns_antoc_action.DASH_BACKWARD) {
-                return ( body_state_nxt = BodyState(ns_antoc_body_state.DASH_BACKWARD, 0, integrity, updated_stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.DASH_BACKWARD, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
             if (intent == ns_antoc_action.JUMP) {
-                return ( body_state_nxt = BodyState(ns_antoc_body_state.JUMP, 0, integrity, updated_stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.JUMP, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
             if (intent == ns_antoc_action.STEP_FORWARD) {
-                return ( body_state_nxt = BodyState(ns_antoc_body_state.STEP_FORWARD, 0, integrity, updated_stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.STEP_FORWARD, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
             if (intent == ns_antoc_action.CYCLONE) {
-                return ( body_state_nxt = BodyState(ns_antoc_body_state.CYCLONE, 0, integrity, updated_stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_antoc_body_state.CYCLONE, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
         }
 
 
         // if counter is full => return to IDLE
         if (counter == ns_antoc_body_state_duration.TAUNT_PARIS23 - 1) {
-            return ( body_state_nxt = BodyState(ns_antoc_body_state.IDLE, 0, integrity, stamina, dir, FALSE) );
+            return ( body_state_nxt = BodyState(ns_antoc_body_state.IDLE, 0, integrity, stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
         }
 
         // else stay and increment counter
-        return ( body_state_nxt = BodyState(ns_antoc_body_state.TAUNT_PARIS23, counter + 1, integrity, stamina, dir, FALSE) );
+        return ( body_state_nxt = BodyState(ns_antoc_body_state.TAUNT_PARIS23, counter + 1, integrity, stamina, dir, FALSE, state_index, opponent_state_index_last_hit) );
     }
 
     // handle exception
     with_attr error_message("Input body state is not recognized.") {
         assert 0 = 1;
     }
-    return ( body_state_nxt = BodyState(0,0,0,0,0,0) );
+    return ( body_state_nxt = BodyState(0,0,0,0,0,0,0,0) );
 }

--- a/8-zed/contracts/body/body_jessica.cairo
+++ b/8-zed/contracts/body/body_jessica.cairo
@@ -4,7 +4,7 @@ from starkware.cairo.common.cairo_builtins import HashBuiltin
 from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.bool import (TRUE, FALSE)
 from starkware.cairo.common.math import unsigned_div_rem
-from starkware.cairo.common.math_cmp import is_le, is_nn_le
+from starkware.cairo.common.math_cmp import is_le, is_nn_le, is_not_zero
 from contracts.constants.constants import (
     BodyState, ns_stimulus, ns_stamina, ns_character_type, HURT_EFFECT, KNOCKED_EFFECT, CLASH_EFFECT
 )
@@ -18,7 +18,10 @@ from contracts.body.body_utils import (
 // Jessica's Body State Diagram
 //
 func _body_jessica {range_check_ptr}(
-        body_state: BodyState, stimulus: felt, intent: felt
+        body_state: BodyState,
+        stimulus: felt,
+        intent: felt,
+        opponent_body_state_index: felt,
     ) -> (
         body_state_nxt: BodyState
 ) {
@@ -30,6 +33,8 @@ func _body_jessica {range_check_ptr}(
     let integrity = body_state.integrity;
     let stamina = body_state.stamina;
     let dir = body_state.dir;
+    let state_index = body_state.state_index;
+    let opponent_state_index_last_hit = body_state.opponent_state_index_last_hit;
 
     // Decode stimulus
     let (stimulus_type, stimulus_damage) = unsigned_div_rem (stimulus, ns_stimulus.ENCODING);
@@ -39,20 +44,24 @@ func _body_jessica {range_check_ptr}(
     let (updated_stamina, enough_stamina) = calculate_stamina_change (stamina, intent, ns_stamina.MAX_STAMINA, ns_character_type.JESSICA);
     let is_fatigued = 1 - enough_stamina;
 
+    // Check if opponent's state_index has progressed from opponent_state_index_last_hit;
+    // for preventing incorrectly registering more than one hit per attack move
+    let opponent_state_index_has_progressed = is_not_zero (opponent_body_state_index - opponent_state_index_last_hit);
+
     //
     // KO
     // not interruptible; not responding to intent
     //
     if (updated_integrity == 0 and state != ns_jessica_body_state.KO) {
-        return ( body_state_nxt = BodyState(ns_jessica_body_state.KO, 0, updated_integrity , stamina, dir, FALSE) );
+        return ( body_state_nxt = BodyState(ns_jessica_body_state.KO, 0, updated_integrity , stamina, dir, FALSE, state_index+1, opponent_body_state_index) );
     }
     if (state == ns_jessica_body_state.KO) {
         if (counter == ns_jessica_body_state_duration.KO - 1) {
             // stop at last frame
-            return ( body_state_nxt = BodyState(ns_jessica_body_state.KO, counter, updated_integrity, updated_stamina, dir, is_fatigued) );
+            return ( body_state_nxt = BodyState(ns_jessica_body_state.KO, counter, updated_integrity, updated_stamina, dir, is_fatigued, state_index, opponent_state_index_last_hit) );
         } else {
             // increment
-            return ( body_state_nxt = BodyState(ns_jessica_body_state.KO, counter + 1, updated_integrity, updated_stamina, dir, is_fatigued) );
+            return ( body_state_nxt = BodyState(ns_jessica_body_state.KO, counter + 1, updated_integrity, updated_stamina, dir, is_fatigued, state_index, opponent_state_index_last_hit) );
         }
     }
 
@@ -62,62 +71,64 @@ func _body_jessica {range_check_ptr}(
     if (state == ns_jessica_body_state.IDLE) {
 
         // body responds to stimulus first
-        if (stimulus_type == ns_stimulus.HURT) {
-            return ( body_state_nxt = BodyState(ns_jessica_body_state.HURT, 0, updated_integrity, stamina, dir, FALSE) );
-        }
-        if (stimulus_type == ns_stimulus.KNOCKED) {
-            return ( body_state_nxt = BodyState(ns_jessica_body_state.KNOCKED, 0, updated_integrity, stamina, dir, FALSE) );
-        }
-        if (stimulus_type == ns_stimulus.LAUNCHED) {
-            return ( body_state_nxt = BodyState(ns_jessica_body_state.LAUNCHED, 0, updated_integrity, stamina, dir, FALSE) );
+        if (opponent_state_index_has_progressed == 1) {
+            if (stimulus_type == ns_stimulus.HURT) {
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.HURT, 0, updated_integrity, stamina, dir, FALSE, state_index+1, opponent_body_state_index) );
+            }
+            if (stimulus_type == ns_stimulus.KNOCKED) {
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.KNOCKED, 0, updated_integrity, stamina, dir, FALSE, state_index+1, opponent_body_state_index) );
+            }
+            if (stimulus_type == ns_stimulus.LAUNCHED) {
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.LAUNCHED, 0, updated_integrity, stamina, dir, FALSE, state_index+1, opponent_body_state_index) );
+            }
         }
 
         // body responds to intent
         if (intent == ns_jessica_action.TAUNT) {
-            return ( body_state_nxt = BodyState(ns_jessica_body_state.TAUNT_PARIS23, 0, integrity, updated_stamina, dir, FALSE) );
+            return ( body_state_nxt = BodyState(ns_jessica_body_state.TAUNT_PARIS23, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
         }
         if (intent == ns_jessica_action.MOVE_FORWARD) {
-            return ( body_state_nxt = BodyState(ns_jessica_body_state.MOVE_FORWARD, 0, integrity, updated_stamina, dir, FALSE) );
+            return ( body_state_nxt = BodyState(ns_jessica_body_state.MOVE_FORWARD, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
         }
         if (intent == ns_jessica_action.MOVE_BACKWARD) {
-            return ( body_state_nxt = BodyState(ns_jessica_body_state.MOVE_BACKWARD, 0, integrity, updated_stamina, dir, FALSE) );
+            return ( body_state_nxt = BodyState(ns_jessica_body_state.MOVE_BACKWARD, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
         }
         if(enough_stamina == TRUE){
             if (intent == ns_jessica_action.BLOCK) {
-                return ( body_state_nxt = BodyState(ns_jessica_body_state.BLOCK, 0, integrity, stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.BLOCK, 0, integrity, stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
             if (intent == ns_jessica_action.SLASH) {
-                return ( body_state_nxt = BodyState(ns_jessica_body_state.SLASH, 0, integrity, updated_stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.SLASH, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
             if (intent == ns_jessica_action.UPSWING) {
-                return ( body_state_nxt = BodyState(ns_jessica_body_state.UPSWING, 0, integrity, updated_stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.UPSWING, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
             if (intent == ns_jessica_action.SIDECUT) {
-                return ( body_state_nxt = BodyState(ns_jessica_body_state.SIDECUT, 0, integrity, updated_stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.SIDECUT, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
             if (intent == ns_jessica_action.LOW_KICK) {
-                return ( body_state_nxt = BodyState(ns_jessica_body_state.LOW_KICK, 0, integrity, updated_stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.LOW_KICK, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
             if (intent == ns_jessica_action.DASH_FORWARD) {
-                return ( body_state_nxt = BodyState(ns_jessica_body_state.DASH_FORWARD, 0, integrity, updated_stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.DASH_FORWARD, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
             if (intent == ns_jessica_action.DASH_BACKWARD) {
-                return ( body_state_nxt = BodyState(ns_jessica_body_state.DASH_BACKWARD, 0, integrity, updated_stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.DASH_BACKWARD, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
             if (intent == ns_jessica_action.JUMP) {
-                return ( body_state_nxt = BodyState(ns_jessica_body_state.JUMP, 0, integrity, updated_stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.JUMP, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
             if (intent == ns_jessica_action.GATOTSU) {
-                return ( body_state_nxt = BodyState(ns_jessica_body_state.GATOTSU, 0, integrity, updated_stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.GATOTSU, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
         }
 
         // otherwise stay in IDLE but increment counter modulo duration
         let (updated_stamina, _) = calculate_stamina_change(stamina, ns_jessica_action.NULL, ns_stamina.MAX_STAMINA, ns_character_type.JESSICA);
         if (counter == ns_jessica_body_state_duration.IDLE - 1) {
-            return ( body_state_nxt = BodyState(ns_jessica_body_state.IDLE, 0, integrity, updated_stamina, dir, is_fatigued) );
+            return ( body_state_nxt = BodyState(ns_jessica_body_state.IDLE, 0, integrity, updated_stamina, dir, is_fatigued, state_index, opponent_state_index_last_hit) );
         } else {
-            return ( body_state_nxt = BodyState(ns_jessica_body_state.IDLE, counter + 1, integrity, updated_stamina, dir, is_fatigued) );
+            return ( body_state_nxt = BodyState(ns_jessica_body_state.IDLE, counter + 1, integrity, updated_stamina, dir, is_fatigued, state_index, opponent_state_index_last_hit) );
         }
     }
 
@@ -127,17 +138,19 @@ func _body_jessica {range_check_ptr}(
     if (state == ns_jessica_body_state.SLASH) {
 
         // body responds to stimulus first
-        if (stimulus_type == ns_stimulus.HURT) {
-            return ( body_state_nxt = BodyState(ns_jessica_body_state.HURT, 0, updated_integrity, stamina, dir, FALSE) );
-        }
-        if (stimulus_type == ns_stimulus.KNOCKED) {
-            return ( body_state_nxt = BodyState(ns_jessica_body_state.KNOCKED, 0, updated_integrity, stamina, dir, FALSE) );
-        }
-        if (stimulus_type == ns_stimulus.CLASH) {
-            return ( body_state_nxt = BodyState(ns_jessica_body_state.CLASH, 0, updated_integrity, stamina, dir, FALSE) );
-        }
-        if (stimulus_type == ns_stimulus.LAUNCHED) {
-            return ( body_state_nxt = BodyState(ns_jessica_body_state.LAUNCHED, 0, updated_integrity, stamina, dir, FALSE) );
+        if (opponent_state_index_has_progressed == 1) {
+            if (stimulus_type == ns_stimulus.HURT) {
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.HURT, 0, updated_integrity, stamina, dir, FALSE, state_index+1, opponent_body_state_index) );
+            }
+            if (stimulus_type == ns_stimulus.KNOCKED) {
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.KNOCKED, 0, updated_integrity, stamina, dir, FALSE, state_index+1, opponent_body_state_index) );
+            }
+            if (stimulus_type == ns_stimulus.CLASH) {
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.CLASH, 0, updated_integrity, stamina, dir, FALSE, state_index+1, opponent_body_state_index) );
+            }
+            if (stimulus_type == ns_stimulus.LAUNCHED) {
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.LAUNCHED, 0, updated_integrity, stamina, dir, FALSE, state_index+1, opponent_body_state_index) );
+            }
         }
 
         // by default finishing the animation; go to frame 1 if intent is SLASH at last frame
@@ -145,16 +158,16 @@ func _body_jessica {range_check_ptr}(
             if (intent == ns_jessica_action.SLASH) {
                 // return to first frame
                 if(enough_stamina == TRUE){
-                    return ( body_state_nxt = BodyState(ns_jessica_body_state.SLASH, 0, integrity, updated_stamina, dir, FALSE) );
+                    return ( body_state_nxt = BodyState(ns_jessica_body_state.SLASH, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
                 } else {
-                    return ( body_state_nxt = BodyState(ns_jessica_body_state.IDLE, 0, integrity, stamina, dir, TRUE) );
+                    return ( body_state_nxt = BodyState(ns_jessica_body_state.IDLE, 0, integrity, stamina, dir, TRUE, state_index+1, opponent_state_index_last_hit) );
                 }
             }
             // otherwise return to IDLE
-            return ( body_state_nxt = BodyState(ns_jessica_body_state.IDLE, 0, integrity, stamina, dir, FALSE) );
+            return ( body_state_nxt = BodyState(ns_jessica_body_state.IDLE, 0, integrity, stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
         } else {
             // increment counter
-            return ( body_state_nxt = BodyState(ns_jessica_body_state.SLASH, counter + 1, integrity, stamina, dir, FALSE) );
+            return ( body_state_nxt = BodyState(ns_jessica_body_state.SLASH, counter + 1, integrity, stamina, dir, FALSE, state_index, opponent_state_index_last_hit) );
         }
 
     }
@@ -166,17 +179,19 @@ func _body_jessica {range_check_ptr}(
     if (state == ns_jessica_body_state.UPSWING) {
 
         // body responds to stimulus first
-        if (stimulus_type == ns_stimulus.HURT) {
-            return ( body_state_nxt = BodyState(ns_jessica_body_state.HURT, 0, updated_integrity, stamina, dir, FALSE) );
-        }
-        if (stimulus_type == ns_stimulus.KNOCKED) {
-            return ( body_state_nxt = BodyState(ns_jessica_body_state.KNOCKED, 0, updated_integrity, stamina, dir, FALSE) );
-        }
-        if (stimulus_type == ns_stimulus.CLASH) {
-            return ( body_state_nxt = BodyState(ns_jessica_body_state.CLASH, 0, updated_integrity, stamina, dir, FALSE) );
-        }
-        if (stimulus_type == ns_stimulus.LAUNCHED) {
-            return ( body_state_nxt = BodyState(ns_jessica_body_state.LAUNCHED, 0, updated_integrity, stamina, dir, FALSE) );
+        if (opponent_state_index_has_progressed == 1) {
+            if (stimulus_type == ns_stimulus.HURT) {
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.HURT, 0, updated_integrity, stamina, dir, FALSE, state_index+1, opponent_body_state_index) );
+            }
+            if (stimulus_type == ns_stimulus.KNOCKED) {
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.KNOCKED, 0, updated_integrity, stamina, dir, FALSE, state_index+1, opponent_body_state_index) );
+            }
+            if (stimulus_type == ns_stimulus.CLASH) {
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.CLASH, 0, updated_integrity, stamina, dir, FALSE, state_index+1, opponent_body_state_index) );
+            }
+            if (stimulus_type == ns_stimulus.LAUNCHED) {
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.LAUNCHED, 0, updated_integrity, stamina, dir, FALSE, state_index+1, opponent_body_state_index) );
+            }
         }
 
         // by default finishing the animation; go to frame 1 if intent is UPSWING at last frame
@@ -184,16 +199,16 @@ func _body_jessica {range_check_ptr}(
             if (intent == ns_jessica_action.UPSWING) {
                 if (enough_stamina == TRUE) {
                     // return to first frame
-                    return ( body_state_nxt = BodyState(ns_jessica_body_state.UPSWING, 0, integrity, updated_stamina, dir, FALSE) );
+                    return ( body_state_nxt = BodyState(ns_jessica_body_state.UPSWING, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
                 } else {
-                    return ( body_state_nxt = BodyState(ns_jessica_body_state.IDLE, 0, integrity, stamina, dir, TRUE) );
+                    return ( body_state_nxt = BodyState(ns_jessica_body_state.IDLE, 0, integrity, stamina, dir, TRUE, state_index+1, opponent_state_index_last_hit) );
                 }
             }
             // otherwise return to IDLE
-            return ( body_state_nxt = BodyState(ns_jessica_body_state.IDLE, 0, integrity, stamina, dir, FALSE) );
+            return ( body_state_nxt = BodyState(ns_jessica_body_state.IDLE, 0, integrity, stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
         } else {
             // increment counter
-            return ( body_state_nxt = BodyState(ns_jessica_body_state.UPSWING, counter + 1, integrity, stamina, dir, FALSE) );
+            return ( body_state_nxt = BodyState(ns_jessica_body_state.UPSWING, counter + 1, integrity, stamina, dir, FALSE, state_index, opponent_state_index_last_hit) );
         }
 
     }
@@ -204,17 +219,19 @@ func _body_jessica {range_check_ptr}(
     if (state == ns_jessica_body_state.SIDECUT) {
 
         // body responds to stimulus first
-        if (stimulus_type == ns_stimulus.HURT) {
-            return ( body_state_nxt = BodyState(ns_jessica_body_state.HURT, 0, updated_integrity, stamina, dir, FALSE) );
-        }
-        if (stimulus_type == ns_stimulus.KNOCKED) {
-            return ( body_state_nxt = BodyState(ns_jessica_body_state.KNOCKED, 0, updated_integrity, stamina, dir, FALSE) );
-        }
-        if (stimulus_type == ns_stimulus.CLASH) {
-            return ( body_state_nxt = BodyState(ns_jessica_body_state.CLASH, 0, updated_integrity, stamina, dir, FALSE) );
-        }
-        if (stimulus_type == ns_stimulus.LAUNCHED) {
-            return ( body_state_nxt = BodyState(ns_jessica_body_state.LAUNCHED, 0, updated_integrity, stamina, dir, FALSE) );
+        if (opponent_state_index_has_progressed == 1) {
+            if (stimulus_type == ns_stimulus.HURT) {
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.HURT, 0, updated_integrity, stamina, dir, FALSE, state_index+1, opponent_body_state_index) );
+            }
+            if (stimulus_type == ns_stimulus.KNOCKED) {
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.KNOCKED, 0, updated_integrity, stamina, dir, FALSE, state_index+1, opponent_body_state_index) );
+            }
+            if (stimulus_type == ns_stimulus.CLASH) {
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.CLASH, 0, updated_integrity, stamina, dir, FALSE, state_index+1, opponent_body_state_index) );
+            }
+            if (stimulus_type == ns_stimulus.LAUNCHED) {
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.LAUNCHED, 0, updated_integrity, stamina, dir, FALSE, state_index+1, opponent_body_state_index) );
+            }
         }
 
         // by default finishing the animation; go to frame 1 if intent is SIDECUT at last frame
@@ -222,16 +239,16 @@ func _body_jessica {range_check_ptr}(
             if (intent == ns_jessica_action.SIDECUT) {
                 if (enough_stamina == TRUE) {
                     // return to first frame
-                    return ( body_state_nxt = BodyState(ns_jessica_body_state.SIDECUT, 0, integrity, updated_stamina, dir, FALSE) );
+                    return ( body_state_nxt = BodyState(ns_jessica_body_state.SIDECUT, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
                 } else {
-                    return ( body_state_nxt = BodyState(ns_jessica_body_state.IDLE, 0, integrity, stamina, dir, TRUE) );
+                    return ( body_state_nxt = BodyState(ns_jessica_body_state.IDLE, 0, integrity, stamina, dir, TRUE, state_index+1, opponent_state_index_last_hit) );
                 }
             }
             // otherwise return to IDLE
-            return ( body_state_nxt = BodyState(ns_jessica_body_state.IDLE, 0, integrity, stamina, dir, FALSE) );
+            return ( body_state_nxt = BodyState(ns_jessica_body_state.IDLE, 0, integrity, stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
         } else {
             // increment counter
-            return ( body_state_nxt = BodyState(ns_jessica_body_state.SIDECUT, counter + 1, integrity, stamina, dir, FALSE) );
+            return ( body_state_nxt = BodyState(ns_jessica_body_state.SIDECUT, counter + 1, integrity, stamina, dir, FALSE, state_index, opponent_state_index_last_hit) );
         }
 
     }
@@ -242,14 +259,16 @@ func _body_jessica {range_check_ptr}(
     if (state == ns_jessica_body_state.BLOCK) {
 
         // body responds to stimulus first
-        if (stimulus_type == ns_stimulus.HURT) {
-            return ( body_state_nxt = BodyState(ns_jessica_body_state.HURT, 0, updated_integrity, stamina, dir, FALSE) );
-        }
-        if (stimulus_type == ns_stimulus.KNOCKED) {
-            return ( body_state_nxt = BodyState(ns_jessica_body_state.KNOCKED, 0, updated_integrity, stamina, dir, FALSE) );
-        }
-        if (stimulus_type == ns_stimulus.LAUNCHED) {
-            return ( body_state_nxt = BodyState(ns_jessica_body_state.LAUNCHED, 0, updated_integrity, stamina, dir, FALSE) );
+        if (opponent_state_index_has_progressed == 1) {
+            if (stimulus_type == ns_stimulus.HURT) {
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.HURT, 0, updated_integrity, stamina, dir, FALSE, state_index+1, opponent_body_state_index) );
+            }
+            if (stimulus_type == ns_stimulus.KNOCKED) {
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.KNOCKED, 0, updated_integrity, stamina, dir, FALSE, state_index+1, opponent_body_state_index) );
+            }
+            if (stimulus_type == ns_stimulus.LAUNCHED) {
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.LAUNCHED, 0, updated_integrity, stamina, dir, FALSE, state_index+1, opponent_body_state_index) );
+            }
         }
 
         // body responds to intent
@@ -258,17 +277,17 @@ func _body_jessica {range_check_ptr}(
             if(enough_stamina == TRUE){
                 if (counter == 1) {
                     // if counter reaches active frame (2nd frame; counter == 1) => stay in active frame
-                    return ( body_state_nxt = BodyState(ns_jessica_body_state.BLOCK, counter, integrity, updated_stamina, dir, FALSE) );
+                    return ( body_state_nxt = BodyState(ns_jessica_body_state.BLOCK, counter, integrity, updated_stamina, dir, FALSE, state_index, opponent_state_index_last_hit) );
                 } else {
                     // else increment counter
-                    return ( body_state_nxt = BodyState(ns_jessica_body_state.BLOCK, counter + 1, integrity, updated_stamina, dir, FALSE) );
+                    return ( body_state_nxt = BodyState(ns_jessica_body_state.BLOCK, counter + 1, integrity, updated_stamina, dir, FALSE, state_index, opponent_state_index_last_hit) );
                 }
             }
         }
 
         // otherwise return to IDLE
         let (updated_stamina, _) = calculate_stamina_change(stamina, ns_jessica_action.BLOCK, ns_stamina.MAX_STAMINA, ns_character_type.JESSICA);
-        return ( body_state_nxt = BodyState(ns_jessica_body_state.IDLE, 0, integrity, updated_stamina, dir, FALSE) );
+        return ( body_state_nxt = BodyState(ns_jessica_body_state.IDLE, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
     }
 
     //
@@ -278,23 +297,25 @@ func _body_jessica {range_check_ptr}(
     if (state == ns_jessica_body_state.CLASH) {
 
         // body responds to stimulus first
-        if (stimulus_type == ns_stimulus.HURT) {
-            return ( body_state_nxt = BodyState(ns_jessica_body_state.HURT, 0, updated_integrity, stamina, dir, FALSE) );
-        }
-        if (stimulus_type == ns_stimulus.KNOCKED) {
-            return ( body_state_nxt = BodyState(ns_jessica_body_state.KNOCKED, 0, updated_integrity, stamina, dir, FALSE) );
-        }
-        if (stimulus_type == ns_stimulus.LAUNCHED) {
-            return ( body_state_nxt = BodyState(ns_jessica_body_state.LAUNCHED, 0, updated_integrity, stamina, dir, FALSE) );
+        if (opponent_state_index_has_progressed == 1) {
+            if (stimulus_type == ns_stimulus.HURT) {
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.HURT, 0, updated_integrity, stamina, dir, FALSE, state_index+1, opponent_body_state_index) );
+            }
+            if (stimulus_type == ns_stimulus.KNOCKED) {
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.KNOCKED, 0, updated_integrity, stamina, dir, FALSE, state_index+1, opponent_body_state_index) );
+            }
+            if (stimulus_type == ns_stimulus.LAUNCHED) {
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.LAUNCHED, 0, updated_integrity, stamina, dir, FALSE, state_index+1, opponent_body_state_index) );
+            }
         }
 
         // if counter is full => return to IDLE
         if (counter == ns_jessica_body_state_duration.CLASH - 1) {
-            return ( body_state_nxt = BodyState(ns_jessica_body_state.IDLE, 0, integrity, stamina, dir, FALSE) );
+            return ( body_state_nxt = BodyState(ns_jessica_body_state.IDLE, 0, integrity, stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
         }
 
         // else stay in CLASH and increment counter
-        return ( body_state_nxt = BodyState(ns_jessica_body_state.CLASH, counter + 1, integrity, stamina, dir, FALSE) );
+        return ( body_state_nxt = BodyState(ns_jessica_body_state.CLASH, counter + 1, integrity, stamina, dir, FALSE, state_index, opponent_state_index_last_hit) );
     }
 
     //
@@ -305,11 +326,11 @@ func _body_jessica {range_check_ptr}(
 
         // if counter is full => return to IDLE
         if (counter == ns_jessica_body_state_duration.HURT - 1) {
-            return ( body_state_nxt = BodyState(ns_jessica_body_state.IDLE, 0, integrity, stamina, dir, FALSE) );
+            return ( body_state_nxt = BodyState(ns_jessica_body_state.IDLE, 0, integrity, stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
         }
 
         // else stay in HURT and increment counter
-        return ( body_state_nxt = BodyState(ns_jessica_body_state.HURT, counter + 1, integrity, stamina, dir, FALSE) );
+        return ( body_state_nxt = BodyState(ns_jessica_body_state.HURT, counter + 1, integrity, stamina, dir, FALSE, state_index, opponent_state_index_last_hit) );
     }
 
     //
@@ -320,16 +341,16 @@ func _body_jessica {range_check_ptr}(
 
         // if counter is full => return to Idle
         if (counter == ns_jessica_body_state_duration.KNOCKED - 1) {
-            return ( body_state_nxt = BodyState(ns_jessica_body_state.IDLE, 0, integrity, stamina, dir, FALSE) );
+            return ( body_state_nxt = BodyState(ns_jessica_body_state.IDLE, 0, integrity, stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
         }
 
         // if reach counter==5 and still in air => remain in counter==5
         if (counter == 5 and stimulus_type != ns_stimulus.GROUND) {
-            return ( body_state_nxt = BodyState(ns_jessica_body_state.KNOCKED, counter, integrity, stamina, dir, FALSE) );
+            return ( body_state_nxt = BodyState(ns_jessica_body_state.KNOCKED, counter, integrity, stamina, dir, FALSE, state_index, opponent_state_index_last_hit) );
         }
 
         // else increment counter
-        return ( body_state_nxt = BodyState(ns_jessica_body_state.KNOCKED, counter + 1, integrity, stamina, dir, FALSE) );
+        return ( body_state_nxt = BodyState(ns_jessica_body_state.KNOCKED, counter + 1, integrity, stamina, dir, FALSE, state_index, opponent_state_index_last_hit) );
     }
 
     //
@@ -338,58 +359,60 @@ func _body_jessica {range_check_ptr}(
     if (state == ns_jessica_body_state.MOVE_FORWARD) {
 
         // interruptible by stimulus
-        if (stimulus_type == ns_stimulus.HURT) {
-            return ( body_state_nxt = BodyState(ns_jessica_body_state.HURT, 0, updated_integrity, stamina, dir, FALSE) );
-        }
-        if (stimulus_type == ns_stimulus.KNOCKED) {
-            return ( body_state_nxt = BodyState(ns_jessica_body_state.KNOCKED, 0, updated_integrity, stamina, dir, FALSE) );
-        }
-        if (stimulus_type == ns_stimulus.LAUNCHED) {
-            return ( body_state_nxt = BodyState(ns_jessica_body_state.LAUNCHED, 0, updated_integrity, stamina, dir, FALSE) );
+        if (opponent_state_index_has_progressed == 1) {
+            if (stimulus_type == ns_stimulus.HURT) {
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.HURT, 0, updated_integrity, stamina, dir, FALSE, state_index+1, opponent_body_state_index) );
+            }
+            if (stimulus_type == ns_stimulus.KNOCKED) {
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.KNOCKED, 0, updated_integrity, stamina, dir, FALSE, state_index+1, opponent_body_state_index) );
+            }
+            if (stimulus_type == ns_stimulus.LAUNCHED) {
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.LAUNCHED, 0, updated_integrity, stamina, dir, FALSE, state_index+1, opponent_body_state_index) );
+            }
         }
 
         // interruptible by agent intent (locomotive action has lowest priority)
         if (intent == ns_jessica_action.TAUNT) {
-            return ( body_state_nxt = BodyState(ns_jessica_body_state.TAUNT_PARIS23, 0, integrity, updated_stamina, dir, FALSE) );
+            return ( body_state_nxt = BodyState(ns_jessica_body_state.TAUNT_PARIS23, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
         }
         if(enough_stamina == TRUE){
             if (intent == ns_jessica_action.BLOCK) {
-                return ( body_state_nxt = BodyState(ns_jessica_body_state.BLOCK, 0, integrity, stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.BLOCK, 0, integrity, stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
             if (intent == ns_jessica_action.SLASH) {
-                return ( body_state_nxt = BodyState(ns_jessica_body_state.SLASH, 0, integrity, stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.SLASH, 0, integrity, stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
             if (intent == ns_jessica_action.UPSWING) {
-                return ( body_state_nxt = BodyState(ns_jessica_body_state.UPSWING, 0, integrity, stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.UPSWING, 0, integrity, stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
             if (intent == ns_jessica_action.SIDECUT) {
-                return ( body_state_nxt = BodyState(ns_jessica_body_state.SIDECUT, 0, integrity, stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.SIDECUT, 0, integrity, stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
             if (intent == ns_jessica_action.LOW_KICK) {
-                return ( body_state_nxt = BodyState(ns_jessica_body_state.LOW_KICK, 0, integrity, updated_stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.LOW_KICK, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
             if (intent == ns_jessica_action.JUMP) {
-                return ( body_state_nxt = BodyState(ns_jessica_body_state.JUMP, 0, integrity, updated_stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.JUMP, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
         }
 
         // continue moving forward
         if (intent == ns_jessica_action.MOVE_FORWARD) {
             if (counter == ns_jessica_body_state_duration.MOVE_FORWARD - 1) {
-                return ( body_state_nxt = BodyState(ns_jessica_body_state.MOVE_FORWARD, 0, integrity, updated_stamina, dir, is_fatigued) );
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.MOVE_FORWARD, 0, integrity, updated_stamina, dir, is_fatigued, state_index, opponent_state_index_last_hit) );
             } else {
-                return ( body_state_nxt = BodyState(ns_jessica_body_state.MOVE_FORWARD, counter + 1, integrity, updated_stamina, dir, is_fatigued) );
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.MOVE_FORWARD, counter + 1, integrity, updated_stamina, dir, is_fatigued, state_index, opponent_state_index_last_hit) );
             }
         }
 
         // able to reverse direction immediately
         if (intent == ns_jessica_action.MOVE_BACKWARD) {
-            return ( body_state_nxt = BodyState(ns_jessica_body_state.MOVE_BACKWARD, 0, integrity, updated_stamina, dir, is_fatigued) );
+            return ( body_state_nxt = BodyState(ns_jessica_body_state.MOVE_BACKWARD, 0, integrity, updated_stamina, dir, is_fatigued, state_index+1, opponent_state_index_last_hit) );
         }
 
         // otherwise return to idle
         let (updated_stamina, _) = calculate_stamina_change(stamina, ns_jessica_action.MOVE_FORWARD, ns_stamina.MAX_STAMINA, ns_character_type.JESSICA);
-        return ( body_state_nxt = BodyState(ns_jessica_body_state.IDLE, 0, integrity, updated_stamina, dir, is_fatigued) );
+        return ( body_state_nxt = BodyState(ns_jessica_body_state.IDLE, 0, integrity, updated_stamina, dir, is_fatigued, state_index+1, opponent_state_index_last_hit) );
     }
 
     //
@@ -398,58 +421,60 @@ func _body_jessica {range_check_ptr}(
     if (state == ns_jessica_body_state.MOVE_BACKWARD) {
 
         // interruptible by stimulus
-        if (stimulus_type == ns_stimulus.HURT) {
-            return ( body_state_nxt = BodyState(ns_jessica_body_state.HURT, 0, updated_integrity, stamina, dir, FALSE) );
-        }
-        if (stimulus_type == ns_stimulus.KNOCKED) {
-            return ( body_state_nxt = BodyState(ns_jessica_body_state.KNOCKED, 0, updated_integrity, stamina, dir, FALSE) );
-        }
-        if (stimulus_type == ns_stimulus.LAUNCHED) {
-            return ( body_state_nxt = BodyState(ns_jessica_body_state.LAUNCHED, 0, updated_integrity, stamina, dir, FALSE) );
+        if (opponent_state_index_has_progressed == 1) {
+            if (stimulus_type == ns_stimulus.HURT) {
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.HURT, 0, updated_integrity, stamina, dir, FALSE, state_index+1, opponent_body_state_index) );
+            }
+            if (stimulus_type == ns_stimulus.KNOCKED) {
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.KNOCKED, 0, updated_integrity, stamina, dir, FALSE, state_index+1, opponent_body_state_index) );
+            }
+            if (stimulus_type == ns_stimulus.LAUNCHED) {
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.LAUNCHED, 0, updated_integrity, stamina, dir, FALSE, state_index+1, opponent_body_state_index) );
+            }
         }
 
         // interruptible by agent intent (locomotive action has lowest priority)
         if (intent == ns_jessica_action.TAUNT) {
-            return ( body_state_nxt = BodyState(ns_jessica_body_state.TAUNT_PARIS23, 0, integrity, updated_stamina, dir, FALSE) );
+            return ( body_state_nxt = BodyState(ns_jessica_body_state.TAUNT_PARIS23, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
         }
         if(enough_stamina == TRUE){
             if (intent == ns_jessica_action.BLOCK) {
-                return ( body_state_nxt = BodyState(ns_jessica_body_state.BLOCK, 0, integrity, stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.BLOCK, 0, integrity, stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
             if (intent == ns_jessica_action.SLASH) {
-                return ( body_state_nxt = BodyState(ns_jessica_body_state.SLASH, 0, integrity, stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.SLASH, 0, integrity, stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
             if (intent == ns_jessica_action.UPSWING) {
-                return ( body_state_nxt = BodyState(ns_jessica_body_state.UPSWING, 0, integrity, stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.UPSWING, 0, integrity, stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
             if (intent == ns_jessica_action.SIDECUT) {
-                return ( body_state_nxt = BodyState(ns_jessica_body_state.SIDECUT, 0, integrity, stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.SIDECUT, 0, integrity, stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
             if (intent == ns_jessica_action.LOW_KICK) {
-                return ( body_state_nxt = BodyState(ns_jessica_body_state.LOW_KICK, 0, integrity, updated_stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.LOW_KICK, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
             if (intent == ns_jessica_action.JUMP) {
-                return ( body_state_nxt = BodyState(ns_jessica_body_state.JUMP, 0, integrity, updated_stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.JUMP, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
         }
 
         // continue moving forward
         if (intent == ns_jessica_action.MOVE_BACKWARD) {
             if (counter == ns_jessica_body_state_duration.MOVE_BACKWARD - 1) {
-                return ( body_state_nxt = BodyState(ns_jessica_body_state.MOVE_BACKWARD, 0, integrity, updated_stamina, dir, is_fatigued) );
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.MOVE_BACKWARD, 0, integrity, updated_stamina, dir, is_fatigued, state_index, opponent_state_index_last_hit) );
             } else {
-                return ( body_state_nxt = BodyState(ns_jessica_body_state.MOVE_BACKWARD, counter + 1, integrity, updated_stamina, dir, is_fatigued) );
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.MOVE_BACKWARD, counter + 1, integrity, updated_stamina, dir, is_fatigued, state_index, opponent_state_index_last_hit) );
             }
         }
 
         // able to reverse direction immediately
         if (intent == ns_jessica_action.MOVE_FORWARD) {
-            return ( body_state_nxt = BodyState(ns_jessica_body_state.MOVE_FORWARD, 0, integrity, updated_stamina, dir, is_fatigued) );
+            return ( body_state_nxt = BodyState(ns_jessica_body_state.MOVE_FORWARD, 0, integrity, updated_stamina, dir, is_fatigued, state_index+1, opponent_state_index_last_hit) );
         }
 
         // otherwise return to idle
         let (updated_stamina, _) = calculate_stamina_change(stamina, ns_jessica_action.MOVE_BACKWARD, ns_stamina.MAX_STAMINA, ns_character_type.JESSICA);
-        return ( body_state_nxt = BodyState(ns_jessica_body_state.IDLE, 0, integrity, updated_stamina, dir, is_fatigued) );
+        return ( body_state_nxt = BodyState(ns_jessica_body_state.IDLE, 0, integrity, updated_stamina, dir, is_fatigued, state_index+1, opponent_state_index_last_hit) );
     }
 
     //
@@ -465,27 +490,27 @@ func _body_jessica {range_check_ptr}(
             // interruptible by offensive intent
             if (intent == ns_jessica_action.SLASH) {
                 // go straight to SLASH's active frame - 1
-                return ( body_state_nxt = BodyState(ns_jessica_body_state.SLASH, 1, integrity, stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.SLASH, 1, integrity, stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
             if (intent == ns_jessica_action.UPSWING) {
                 // go straight to UPSWING's active frame - 1
-                return ( body_state_nxt = BodyState(ns_jessica_body_state.UPSWING, 1, integrity, updated_stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.UPSWING, 1, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
             if (intent == ns_jessica_action.SIDECUT) {
                 // go straight to SIDECUT's active frame - 1
-                return ( body_state_nxt = BodyState(ns_jessica_body_state.SIDECUT, 1, integrity, updated_stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.SIDECUT, 1, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
 
             // interruptible by jump
             if (intent == ns_jessica_action.JUMP) {
-                return ( body_state_nxt = BodyState(ns_jessica_body_state.JUMP, 0, integrity, updated_stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.JUMP, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
         }
 
         // can cancel dash into BIRDSWING's counter==2 while not grounded
         if(enough_stamina == TRUE and stimulus_type != ns_stimulus.GROUND) {
             if (intent == ns_jessica_action.SIDECUT) {
-                return ( body_state_nxt = BodyState(ns_jessica_body_state.BIRDSWING, 2, integrity, stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.BIRDSWING, 2, integrity, stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
         }
 
@@ -493,18 +518,18 @@ func _body_jessica {range_check_ptr}(
         if (counter == ns_jessica_body_state_duration.DASH_FORWARD - 1) {
             // if not grounded => return to JUMP's counter==4
             if (stimulus_type != ns_stimulus.GROUND) {
-                return ( body_state_nxt = BodyState(ns_jessica_body_state.JUMP, 4, integrity, updated_stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.JUMP, 4, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
 
             // continue the dashing if not interrupted by an attack
             if(enough_stamina == TRUE and intent == ns_jessica_body_state_duration.DASH_FORWARD){
                 // reset counter
-                return ( body_state_nxt = BodyState(ns_jessica_body_state.DASH_FORWARD, 0, integrity, updated_stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.DASH_FORWARD, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
-            return ( body_state_nxt = BodyState(ns_jessica_body_state.IDLE, 0, integrity, stamina, dir, TRUE) );
+            return ( body_state_nxt = BodyState(ns_jessica_body_state.IDLE, 0, integrity, stamina, dir, TRUE, state_index+1, opponent_state_index_last_hit) );
         }
         // increment counter
-        return ( body_state_nxt = BodyState(ns_jessica_body_state.DASH_FORWARD, counter + 1, integrity, stamina, dir, FALSE) );
+        return ( body_state_nxt = BodyState(ns_jessica_body_state.DASH_FORWARD, counter + 1, integrity, stamina, dir, FALSE, state_index, opponent_state_index_last_hit) );
     }
 
     //
@@ -517,27 +542,27 @@ func _body_jessica {range_check_ptr}(
             // interruptible by offensive intent
             if (intent == ns_jessica_action.SLASH) {
                 // go straight to SLASH's active frame - 1
-                return ( body_state_nxt = BodyState(ns_jessica_body_state.SLASH, 1, integrity, updated_stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.SLASH, 1, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
             if (intent == ns_jessica_action.UPSWING) {
                 // go straight to UPSWING's active frame
-                return ( body_state_nxt = BodyState(ns_jessica_body_state.UPSWING, 1, integrity, updated_stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.UPSWING, 1, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
             if (intent == ns_jessica_action.SIDECUT) {
                 // go straight to SIDECUT's active frame
-                return ( body_state_nxt = BodyState(ns_jessica_body_state.SIDECUT, 1, integrity, updated_stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.SIDECUT, 1, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
 
             // interruptible by jump
             if (intent == ns_jessica_action.JUMP) {
-                return ( body_state_nxt = BodyState(ns_jessica_body_state.JUMP, 0, integrity, updated_stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.JUMP, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
         }
 
         // can cancel dash into BIRDSWING's counter==2 while not grounded
         if(enough_stamina == TRUE and stimulus_type != ns_stimulus.GROUND) {
             if (intent == ns_jessica_action.SIDECUT) {
-                return ( body_state_nxt = BodyState(ns_jessica_body_state.BIRDSWING, 2, integrity, stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.BIRDSWING, 2, integrity, stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
         }
 
@@ -545,18 +570,18 @@ func _body_jessica {range_check_ptr}(
         if (counter == ns_jessica_body_state_duration.DASH_BACKWARD - 1) {
             // if not grounded => return to JUMP's counter==4
             if (stimulus_type != ns_stimulus.GROUND) {
-                return ( body_state_nxt = BodyState(ns_jessica_body_state.JUMP, 4, integrity, updated_stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.JUMP, 4, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
 
             // continue the dashing if not interrupted by an attack
             if(enough_stamina == TRUE and intent == ns_jessica_body_state_duration.DASH_BACKWARD) {
                 // reset counter
-                return ( body_state_nxt = BodyState(ns_jessica_body_state.DASH_BACKWARD, 0, integrity, updated_stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.DASH_BACKWARD, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
-            return ( body_state_nxt = BodyState(ns_jessica_body_state.IDLE, 0, integrity, stamina, dir, TRUE) );
+            return ( body_state_nxt = BodyState(ns_jessica_body_state.IDLE, 0, integrity, stamina, dir, TRUE, state_index+1, opponent_state_index_last_hit) );
         }
         // increment counter
-        return ( body_state_nxt = BodyState(ns_jessica_body_state.DASH_BACKWARD, counter + 1, integrity, stamina, dir, FALSE) );
+        return ( body_state_nxt = BodyState(ns_jessica_body_state.DASH_BACKWARD, counter + 1, integrity, stamina, dir, FALSE, state_index, opponent_state_index_last_hit) );
     }
 
     //
@@ -565,52 +590,54 @@ func _body_jessica {range_check_ptr}(
     //
     if ((state-ns_jessica_body_state.JUMP)*(state-ns_jessica_body_state.JUMP_MOVE_FORWARD)*(state-ns_jessica_body_state.JUMP_MOVE_BACKWARD) == 0) {
 
-        // can be knocked
-        if (stimulus_type == ns_stimulus.KNOCKED) {
-            return ( body_state_nxt = BodyState(ns_jessica_body_state.KNOCKED, 0, updated_integrity, stamina, dir, FALSE) );
-        }
-        if (stimulus_type == ns_stimulus.LAUNCHED) {
-            return ( body_state_nxt = BodyState(ns_jessica_body_state.LAUNCHED, 0, updated_integrity, stamina, dir, FALSE) );
+        if (opponent_state_index_has_progressed == 1) {
+            // can be knocked
+            if (stimulus_type == ns_stimulus.KNOCKED) {
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.KNOCKED, 0, updated_integrity, stamina, dir, FALSE, state_index+1, opponent_body_state_index) );
+            }
+            if (stimulus_type == ns_stimulus.LAUNCHED) {
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.LAUNCHED, 0, updated_integrity, stamina, dir, FALSE, state_index+1, opponent_body_state_index) );
+            }
         }
 
         // SIDECUT during counter!=0 becomes birdswing's counter==0
         if (intent == ns_jessica_action.SIDECUT and counter != 0) {
-            return ( body_state_nxt = BodyState(ns_jessica_body_state.BIRDSWING, 0, integrity, updated_stamina, dir, FALSE) );
+            return ( body_state_nxt = BodyState(ns_jessica_body_state.BIRDSWING, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
         }
 
         // DASH FORWARD/BACKWARD during counter!=0/4/5 (ie counter==1/2/3) becomes dash forward/backward's counter==0
         // note: this is to prevent multiple air dashes during the same jump
         if ((counter-1) * (counter-2) * (counter-3) == 0) {
             if (intent == ns_jessica_action.DASH_FORWARD) {
-                return ( body_state_nxt = BodyState(ns_jessica_body_state.DASH_FORWARD, 0, integrity, updated_stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.DASH_FORWARD, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
             if (intent == ns_jessica_action.DASH_BACKWARD) {
-                return ( body_state_nxt = BodyState(ns_jessica_body_state.DASH_BACKWARD, 0, integrity, updated_stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.DASH_BACKWARD, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
         }
 
         // if counter is full => return to IDLE
         if (counter == ns_jessica_body_state_duration.JUMP - 1) {
-            return ( body_state_nxt = BodyState(ns_jessica_body_state.IDLE, 0, integrity, stamina, dir, FALSE) );
+            return ( body_state_nxt = BodyState(ns_jessica_body_state.IDLE, 0, integrity, stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
         }
 
         // if reach counter==4 and still in air => remain in the same state with counter==4
         if (counter == 4 and stimulus_type != ns_stimulus.GROUND) {
-            return ( body_state_nxt = BodyState(state, counter, integrity, stamina, dir, FALSE) );
+            return ( body_state_nxt = BodyState(state, counter, integrity, stamina, dir, FALSE, state_index, opponent_state_index_last_hit) );
         }
 
         // MOVE FORWARD/BACKWARD during counter!=0/5 (counter == 1/2/3/4) becomes JUMP_MOVE_FORWARD/BACKWARD's counter+1
         if ((counter-1)*(counter-2)*(counter-3)*(counter-4) == 0) {
             if (intent == ns_jessica_action.MOVE_FORWARD) {
-                return ( body_state_nxt = BodyState(ns_jessica_body_state.JUMP_MOVE_FORWARD, counter+1, integrity, updated_stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.JUMP_MOVE_FORWARD, counter+1, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
             if (intent == ns_jessica_action.MOVE_BACKWARD) {
-                return ( body_state_nxt = BodyState(ns_jessica_body_state.JUMP_MOVE_BACKWARD, counter+1, integrity, updated_stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.JUMP_MOVE_BACKWARD, counter+1, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
         }
 
         // else stay in the same state and increment counter
-        return ( body_state_nxt = BodyState(state, counter + 1, integrity, stamina, dir, FALSE) );
+        return ( body_state_nxt = BodyState(state, counter + 1, integrity, stamina, dir, FALSE, state_index, opponent_state_index_last_hit) );
     }
 
     //
@@ -619,17 +646,19 @@ func _body_jessica {range_check_ptr}(
     //
     if (state == ns_jessica_body_state.GATOTSU) {
 
-        if (stimulus_type == ns_stimulus.CLASH) {
-            return ( body_state_nxt = BodyState(ns_jessica_body_state.CLASH, 0, updated_integrity, stamina, dir, FALSE) );
+        if (opponent_state_index_has_progressed == 1) {
+            if (stimulus_type == ns_stimulus.CLASH) {
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.CLASH, 0, updated_integrity, stamina, dir, FALSE, state_index+1, opponent_body_state_index) );
+            }
         }
 
         // if counter is full => return to IDLE
         if (counter == ns_jessica_body_state_duration.GATOTSU - 1) {
-            return ( body_state_nxt = BodyState(ns_jessica_body_state.IDLE, 0, integrity, stamina, dir, FALSE) );
+            return ( body_state_nxt = BodyState(ns_jessica_body_state.IDLE, 0, integrity, stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
         }
 
         // else stay in GATOTSU and increment counter
-        return ( body_state_nxt = BodyState(ns_jessica_body_state.GATOTSU, counter + 1, integrity, stamina, dir, FALSE) );
+        return ( body_state_nxt = BodyState(ns_jessica_body_state.GATOTSU, counter + 1, integrity, stamina, dir, FALSE, state_index, opponent_state_index_last_hit) );
     }
 
     //
@@ -638,40 +667,42 @@ func _body_jessica {range_check_ptr}(
     if (state == ns_jessica_body_state.LOW_KICK) {
 
         // body responds to stimulus first
-        if (stimulus_type == ns_stimulus.HURT) {
-            return ( body_state_nxt = BodyState(ns_jessica_body_state.HURT, 0, updated_integrity, stamina, dir, FALSE) );
-        }
-        if (stimulus_type == ns_stimulus.KNOCKED) {
-            return ( body_state_nxt = BodyState(ns_jessica_body_state.KNOCKED, 0, updated_integrity, stamina, dir, FALSE) );
-        }
-        if (stimulus_type == ns_stimulus.CLASH) {
-            return ( body_state_nxt = BodyState(ns_jessica_body_state.CLASH, 0, updated_integrity, stamina, dir, FALSE) );
-        }
-        if (stimulus_type == ns_stimulus.LAUNCHED) {
-            return ( body_state_nxt = BodyState(ns_jessica_body_state.LAUNCHED, 0, updated_integrity, stamina, dir, FALSE) );
+        if (opponent_state_index_has_progressed == 1) {
+            if (stimulus_type == ns_stimulus.HURT) {
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.HURT, 0, updated_integrity, stamina, dir, FALSE, state_index+1, opponent_body_state_index) );
+            }
+            if (stimulus_type == ns_stimulus.KNOCKED) {
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.KNOCKED, 0, updated_integrity, stamina, dir, FALSE, state_index+1, opponent_body_state_index) );
+            }
+            if (stimulus_type == ns_stimulus.CLASH) {
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.CLASH, 0, updated_integrity, stamina, dir, FALSE, state_index+1, opponent_body_state_index) );
+            }
+            if (stimulus_type == ns_stimulus.LAUNCHED) {
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.LAUNCHED, 0, updated_integrity, stamina, dir, FALSE, state_index+1, opponent_body_state_index) );
+            }
         }
 
         // body responds to intent
         // LOW_KICK at recovery frame is cancellable into UPSWING's counter==1 or DASH_BACKWARD's counter==0
         if ((counter-4) * (counter-5) == 0 and enough_stamina == TRUE) {
             if (intent == ns_jessica_action.UPSWING) {
-                return ( body_state_nxt = BodyState(ns_jessica_body_state.UPSWING, 1, integrity, updated_stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.UPSWING, 1, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
             if (intent == ns_jessica_action.DASH_BACKWARD) {
-                return ( body_state_nxt = BodyState(ns_jessica_body_state.DASH_BACKWARD, 0, integrity, updated_stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.DASH_BACKWARD, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
         }
 
         // after the last frame, go to *second frame* if intent is LOW_KICK
         if (counter == ns_jessica_body_state_duration.LOW_KICK - 1) {
             if (intent == ns_jessica_action.LOW_KICK and enough_stamina == TRUE) {
-                return ( body_state_nxt = BodyState(ns_jessica_body_state.LOW_KICK, 0, integrity, updated_stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.LOW_KICK, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
             // otherwise return to IDLE
-            return ( body_state_nxt = BodyState(ns_jessica_body_state.IDLE, 0, integrity, stamina, dir, FALSE) );
+            return ( body_state_nxt = BodyState(ns_jessica_body_state.IDLE, 0, integrity, stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
         } else {
             // increment counter
-            return ( body_state_nxt = BodyState(ns_jessica_body_state.LOW_KICK, counter + 1, integrity, stamina, dir, FALSE) );
+            return ( body_state_nxt = BodyState(ns_jessica_body_state.LOW_KICK, counter + 1, integrity, stamina, dir, FALSE, state_index, opponent_state_index_last_hit) );
         }
 
     }
@@ -681,12 +712,14 @@ func _body_jessica {range_check_ptr}(
     //
     if (state == ns_jessica_body_state.BIRDSWING) {
 
-        // can be knocked
-        if (stimulus_type == ns_stimulus.KNOCKED) {
-            return ( body_state_nxt = BodyState(ns_jessica_body_state.KNOCKED, 0, updated_integrity, stamina, dir, FALSE) );
-        }
-        if (stimulus_type == ns_stimulus.LAUNCHED) {
-            return ( body_state_nxt = BodyState(ns_jessica_body_state.LAUNCHED, 0, updated_integrity, stamina, dir, FALSE) );
+        if (opponent_state_index_has_progressed == 1) {
+            // can be knocked
+            if (stimulus_type == ns_stimulus.KNOCKED) {
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.KNOCKED, 0, updated_integrity, stamina, dir, FALSE, state_index+1, opponent_body_state_index) );
+            }
+            if (stimulus_type == ns_stimulus.LAUNCHED) {
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.LAUNCHED, 0, updated_integrity, stamina, dir, FALSE, state_index+1, opponent_body_state_index) );
+            }
         }
 
         // if counter is full =>
@@ -694,14 +727,14 @@ func _body_jessica {range_check_ptr}(
         //   otherwise return to IDLE
         if (counter == ns_jessica_body_state_duration.BIRDSWING - 1) {
             if (stimulus_type != ns_stimulus.GROUND) {
-                return ( body_state_nxt = BodyState(ns_jessica_body_state.JUMP, 4, integrity, stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.JUMP, 4, integrity, stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             } else {
-                return ( body_state_nxt = BodyState(ns_jessica_body_state.IDLE, 0, integrity, stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.IDLE, 0, integrity, stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
         }
 
         // else stay in BIRDSWING and increment counter
-        return ( body_state_nxt = BodyState(ns_jessica_body_state.BIRDSWING, counter + 1, integrity, stamina, dir, FALSE) );
+        return ( body_state_nxt = BodyState(ns_jessica_body_state.BIRDSWING, counter + 1, integrity, stamina, dir, FALSE, state_index, opponent_state_index_last_hit) );
     }
 
     //
@@ -710,27 +743,29 @@ func _body_jessica {range_check_ptr}(
     //
     if (state == ns_jessica_body_state.LAUNCHED) {
 
-        // can be knocked
-        if (stimulus_type == ns_stimulus.KNOCKED) {
-            return ( body_state_nxt = BodyState(ns_jessica_body_state.KNOCKED, 0, updated_integrity, stamina, dir, FALSE) );
-        }
-        // can be juggled
-        if (stimulus_type == ns_stimulus.LAUNCHED) {
-            return ( body_state_nxt = BodyState(ns_jessica_body_state.LAUNCHED, 0, updated_integrity, stamina, dir, FALSE) );
+        if (opponent_state_index_has_progressed == 1) {
+            // can be knocked
+            if (stimulus_type == ns_stimulus.KNOCKED) {
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.KNOCKED, 0, updated_integrity, stamina, dir, FALSE, state_index+1, opponent_body_state_index) );
+            }
+            // can be juggled
+            if (stimulus_type == ns_stimulus.LAUNCHED) {
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.LAUNCHED, 0, updated_integrity, stamina, dir, FALSE, state_index+1, opponent_body_state_index) );
+            }
         }
 
         // if counter is full => return to IDLE
         if (counter == ns_jessica_body_state_duration.LAUNCHED - 1) {
-            return ( body_state_nxt = BodyState(ns_jessica_body_state.IDLE, 0, integrity, stamina, dir, FALSE) );
+            return ( body_state_nxt = BodyState(ns_jessica_body_state.IDLE, 0, integrity, stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
         }
 
         // if reach counter==5 and still in air => remain in counter==5
         if (counter == 5 and stimulus_type != ns_stimulus.GROUND) {
-            return ( body_state_nxt = BodyState(ns_jessica_body_state.LAUNCHED, counter, integrity, stamina, dir, FALSE) );
+            return ( body_state_nxt = BodyState(ns_jessica_body_state.LAUNCHED, counter, integrity, stamina, dir, FALSE, state_index, opponent_state_index_last_hit) );
         }
 
         // else stay in LAUNCHED and increment counter
-        return ( body_state_nxt = BodyState(ns_jessica_body_state.LAUNCHED, counter + 1, integrity, stamina, dir, FALSE) );
+        return ( body_state_nxt = BodyState(ns_jessica_body_state.LAUNCHED, counter + 1, integrity, stamina, dir, FALSE, state_index, opponent_state_index_last_hit) );
     }
 
     //
@@ -739,64 +774,66 @@ func _body_jessica {range_check_ptr}(
     if (state == ns_jessica_body_state.TAUNT_PARIS23) {
 
         // body responds to stimulus first
-        if (stimulus_type == ns_stimulus.HURT) {
-            return ( body_state_nxt = BodyState(ns_jessica_body_state.HURT, 0, updated_integrity, stamina, dir, FALSE) );
-        }
-        if (stimulus_type == ns_stimulus.KNOCKED) {
-            return ( body_state_nxt = BodyState(ns_jessica_body_state.KNOCKED, 0, updated_integrity, stamina, dir, FALSE) );
-        }
-        if (stimulus_type == ns_stimulus.LAUNCHED) {
-            return ( body_state_nxt = BodyState(ns_jessica_body_state.LAUNCHED, 0, updated_integrity, stamina, dir, FALSE) );
+        if (opponent_state_index_has_progressed == 1) {
+            if (stimulus_type == ns_stimulus.HURT) {
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.HURT, 0, updated_integrity, stamina, dir, FALSE, state_index+1, opponent_body_state_index) );
+            }
+            if (stimulus_type == ns_stimulus.KNOCKED) {
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.KNOCKED, 0, updated_integrity, stamina, dir, FALSE, state_index+1, opponent_body_state_index) );
+            }
+            if (stimulus_type == ns_stimulus.LAUNCHED) {
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.LAUNCHED, 0, updated_integrity, stamina, dir, FALSE, state_index+1, opponent_body_state_index) );
+            }
         }
 
         // body responds to intent; locomotive action has lowest priority
         if (intent == ns_jessica_action.MOVE_FORWARD) {
-            return ( body_state_nxt = BodyState(ns_jessica_body_state.MOVE_FORWARD, 0, integrity, updated_stamina, dir, FALSE) );
+            return ( body_state_nxt = BodyState(ns_jessica_body_state.MOVE_FORWARD, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
         }
         if (intent == ns_jessica_action.MOVE_BACKWARD) {
-            return ( body_state_nxt = BodyState(ns_jessica_body_state.MOVE_BACKWARD, 0, integrity, updated_stamina, dir, FALSE) );
+            return ( body_state_nxt = BodyState(ns_jessica_body_state.MOVE_BACKWARD, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
         }
         if(enough_stamina == TRUE){
             if (intent == ns_jessica_action.BLOCK) {
-                return ( body_state_nxt = BodyState(ns_jessica_body_state.BLOCK, 0, integrity, stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.BLOCK, 0, integrity, stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
             if (intent == ns_jessica_action.SLASH) {
-                return ( body_state_nxt = BodyState(ns_jessica_body_state.SLASH, 0, integrity, updated_stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.SLASH, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
             if (intent == ns_jessica_action.UPSWING) {
-                return ( body_state_nxt = BodyState(ns_jessica_body_state.UPSWING, 0, integrity, updated_stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.UPSWING, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
             if (intent == ns_jessica_action.SIDECUT) {
-                return ( body_state_nxt = BodyState(ns_jessica_body_state.SIDECUT, 0, integrity, updated_stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.SIDECUT, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
             if (intent == ns_jessica_action.LOW_KICK) {
-                return ( body_state_nxt = BodyState(ns_jessica_body_state.LOW_KICK, 0, integrity, updated_stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.LOW_KICK, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
             if (intent == ns_jessica_action.DASH_FORWARD) {
-                return ( body_state_nxt = BodyState(ns_jessica_body_state.DASH_FORWARD, 0, integrity, updated_stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.DASH_FORWARD, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
             if (intent == ns_jessica_action.DASH_BACKWARD) {
-                return ( body_state_nxt = BodyState(ns_jessica_body_state.DASH_BACKWARD, 0, integrity, updated_stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.DASH_BACKWARD, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
             if (intent == ns_jessica_action.JUMP) {
-                return ( body_state_nxt = BodyState(ns_jessica_body_state.JUMP, 0, integrity, updated_stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.JUMP, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
             if (intent == ns_jessica_action.GATOTSU) {
-                return ( body_state_nxt = BodyState(ns_jessica_body_state.GATOTSU, 0, integrity, updated_stamina, dir, FALSE) );
+                return ( body_state_nxt = BodyState(ns_jessica_body_state.GATOTSU, 0, integrity, updated_stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
             }
         }
 
         // if counter is full => return to IDLE
         if (counter == ns_jessica_body_state_duration.TAUNT_PARIS23 - 1) {
-            return ( body_state_nxt = BodyState(ns_jessica_body_state.IDLE, 0, integrity, stamina, dir, FALSE) );
+            return ( body_state_nxt = BodyState(ns_jessica_body_state.IDLE, 0, integrity, stamina, dir, FALSE, state_index+1, opponent_state_index_last_hit) );
         }
 
         // else stay and increment counter
-        return ( body_state_nxt = BodyState(ns_jessica_body_state.TAUNT_PARIS23, counter + 1, integrity, stamina, dir, FALSE) );
+        return ( body_state_nxt = BodyState(ns_jessica_body_state.TAUNT_PARIS23, counter + 1, integrity, stamina, dir, FALSE, state_index, opponent_state_index_last_hit) );
     }
 
     with_attr error_message("Input body state is not recognized.") {
         assert 0 = 1;
     }
-    return ( body_state_nxt = BodyState(0,0,0,0,0, 0) );
+    return ( body_state_nxt = BodyState(0,0,0,0,0,0,0,0) );
 }

--- a/8-zed/contracts/constants/constants.cairo
+++ b/8-zed/contracts/constants/constants.cairo
@@ -117,6 +117,8 @@ struct BodyState {
     stamina: felt,
     dir: felt,
     fatigued : felt,
+    state_index: felt,
+    opponent_state_index_last_hit: felt,
 }
 
 struct PhysicsState {

--- a/8-zed/contracts/constants/constants_jessica.cairo
+++ b/8-zed/contracts/constants/constants_jessica.cairo
@@ -203,13 +203,9 @@ namespace ns_jessica_body_state_qualifiers {
             return 1;
         }
 
-        // if (counter == 4) {
-        //     return 1;
-        // }
-
-        // if (counter == 5) {
-        //     return 1;
-        // }
+        if (counter == 4) {
+            return 1;
+        }
 
         return 0;
     }

--- a/8-zed/contracts/engine.cairo
+++ b/8-zed/contracts/engine.cairo
@@ -197,7 +197,7 @@ func loop{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
     assert arr_frames[0] = FrameScene(
         agent_0 = Frame(
             mental_state  = agent_0_initial_state,
-            body_state    = BodyState(0, 0, ns_integrity.INIT_INTEGRITY, ns_stamina.INIT_STAMINA, 1, 0),
+            body_state    = BodyState(0, 0, ns_integrity.INIT_INTEGRITY, ns_stamina.INIT_STAMINA, 1, 0, 0, -1),
             physics_state = physics_state_0,
             action        = 0,
             stimulus      = ns_stimulus.GROUND * ns_stimulus.ENCODING,
@@ -212,7 +212,7 @@ func loop{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
             ),
         agent_1 = Frame(
             mental_state  = agent_1_initial_state,
-            body_state    = BodyState(0, 0, ns_integrity.INIT_INTEGRITY, ns_stamina.INIT_STAMINA, 0, 0),
+            body_state    = BodyState(0, 0, ns_integrity.INIT_INTEGRITY, ns_stamina.INIT_STAMINA, 0, 0, 0, -1),
             physics_state = physics_state_1,
             action        = 0,
             stimulus      = ns_stimulus.GROUND * ns_stimulus.ENCODING,
@@ -446,12 +446,14 @@ func _loop{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
         body_state     = last_frame.agent_0.body_state,
         stimulus       = last_frame.agent_0.stimulus,
         intent         = a_0,
+        opponent_body_state_index = last_frame.agent_1.body_state.state_index,
     );
     let (body_state_1 : BodyState) = _body (
         character_type = character_type_1,
         body_state     = last_frame.agent_1.body_state,
         stimulus       = last_frame.agent_1.stimulus,
         intent         = a_1,
+        opponent_body_state_index = last_frame.agent_0.body_state.state_index,
     );
 
     //
@@ -493,6 +495,8 @@ func _loop{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
                 stamina = new_rage_0,
                 dir = new_dir_0,
                 fatigued = body_state_0.fatigued,
+                state_index = body_state_0.state_index,
+                opponent_state_index_last_hit = body_state_0.opponent_state_index_last_hit,
             ),
             physics_state = physics_state_0,
             action        = a_0,
@@ -512,6 +516,8 @@ func _loop{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
                 stamina = new_rage_1,
                 dir = new_dir_1,
                 fatigued = body_state_1.fatigued,
+                state_index = body_state_1.state_index,
+                opponent_state_index_last_hit = body_state_1.opponent_state_index_last_hit,
             ),
             physics_state = physics_state_1,
             action        = a_1,
@@ -554,6 +560,8 @@ func playerInLoop{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_pt
         agent_0_body_state_stamina: felt,
         agent_0_body_state_dir: felt,
         agent_0_body_state_fatigued: felt,
+        agent_0_body_state_state_index: felt,
+        agent_0_body_state_opponent_state_index_last_hit: felt,
 
         agent_0_physics_state_pos_x: felt,
         agent_0_physics_state_pos_y: felt,
@@ -572,6 +580,8 @@ func playerInLoop{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_pt
         agent_1_body_state_stamina: felt,
         agent_1_body_state_dir: felt,
         agent_1_body_state_fatigued: felt,
+        agent_1_body_state_state_index: felt,
+        agent_1_body_state_opponent_state_index_last_hit: felt,
 
         agent_1_physics_state_pos_x: felt,
         agent_1_physics_state_pos_y: felt,
@@ -640,6 +650,8 @@ func playerInLoop{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_pt
         stamina=agent_0_body_state_stamina,
         dir=agent_0_body_state_dir,
         fatigued=agent_0_body_state_fatigued,
+        state_index=agent_0_body_state_state_index,
+        opponent_state_index_last_hit=agent_0_body_state_opponent_state_index_last_hit,
     );
 
     let agent_0_position = Vec2(agent_0_physics_state_pos_x, agent_0_physics_state_pos_y);
@@ -657,7 +669,9 @@ func playerInLoop{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_pt
         agent_1_body_state_integrity,
         agent_1_body_state_stamina,
         agent_1_body_state_dir,
-        agent_1_body_state_fatigued
+        agent_1_body_state_fatigued,
+        state_index=agent_1_body_state_state_index,
+        opponent_state_index_last_hit=agent_1_body_state_opponent_state_index_last_hit,
     );
 
     let agent_1_position = Vec2(agent_1_physics_state_pos_x, agent_1_physics_state_pos_y);
@@ -740,12 +754,14 @@ func playerInLoop{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_pt
         body_state     = agent_0_body_state,
         stimulus       = agent_0_stimulus,
         intent         = agent_0_action,
+        opponent_body_state_index = agent_1_body_state_state_index,
     );
     let (body_state_1 : BodyState) = _body (
         character_type = agent_1_character_type,
         body_state     = agent_1_body_state,
         stimulus       = agent_1_stimulus,
         intent         = agent_1_action,
+        opponent_body_state_index = agent_0_body_state_state_index,
     );
 
     //
@@ -793,6 +809,8 @@ func playerInLoop{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_pt
                 stamina = new_rage_0,
                 dir = new_dir_0,
                 fatigued = body_state_0.fatigued,
+                state_index = body_state_0.state_index,
+                opponent_state_index_last_hit = body_state_0.opponent_state_index_last_hit,
             ),
             physics_state=physics_state_0,
             stimulus=stimulus_0,
@@ -806,6 +824,8 @@ func playerInLoop{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_pt
                 stamina = new_rage_1,
                 dir = new_dir_1,
                 fatigued = body_state_1.fatigued,
+                state_index = body_state_1.state_index,
+                opponent_state_index_last_hit = body_state_1.opponent_state_index_last_hit,
             ),
             physics_state=physics_state_1,
             stimulus=stimulus_1,


### PR DESCRIPTION
### Description
This PR enables multiple active frames per attack move without registering more than one hit within the same attack.

### Approach
Add two new fields to `BodyState` struct:
1. `state_index`, which is a increment-only counter that changes when body state transition occurs.
2. `opponent_state_index_last_hit`, which records the value of _opponent's_ `state_index` when myself was hit last time; hit includes transitioning into hurt, knocked, launched, and clashed.

For Jessica and Antoc's body contract function, they are also receiving opponent's current `state_index` as input.

These changes allow the body contract function to check for inequality between self's `opponent_state_index_last_hit` and opponent's current `state_index`. Then, when self's body receives a hit stimulus (hurt, knocked, launched, clashed), transition into corresponding state occurs **only if** the inequality holds ie "my opponent's body has progressed from the state when they hit me last time"