### PR TITLE
Fix dash push bug + action hitbox positioning bug

### DIFF
--- a/8-zed/contracts/constants/constants.cairo
+++ b/8-zed/contracts/constants/constants.cairo
@@ -18,7 +18,7 @@ namespace ns_dynamics {
 
     const GRAVITY_ACC_FP = -2500 * ns_dynamics.SCALE_FP;
     const LOW_GRAVITY_ACC_FP = -2000 * ns_dynamics.SCALE_FP;
-    const FRICTION_ACC_FP = 10000 * ns_dynamics.SCALE_FP;
+    const FRICTION_ACC_FP = 6000 * ns_dynamics.SCALE_FP;
 
     const BACKOFF_VEL_X_FP = 200 * ns_dynamics.SCALE_FP;
     const BLOCK_BACKOFF_VEL_X_FP = 75 * ns_dynamics.SCALE_FP;

--- a/8-zed/contracts/constants/constants.cairo
+++ b/8-zed/contracts/constants/constants.cairo
@@ -18,7 +18,7 @@ namespace ns_dynamics {
 
     const GRAVITY_ACC_FP = -2500 * ns_dynamics.SCALE_FP;
     const LOW_GRAVITY_ACC_FP = -2000 * ns_dynamics.SCALE_FP;
-    const FRICTION_ACC_FP = 500 * ns_dynamics.SCALE_FP;
+    const FRICTION_ACC_FP = 10000 * ns_dynamics.SCALE_FP;
 
     const BACKOFF_VEL_X_FP = 200 * ns_dynamics.SCALE_FP;
     const BLOCK_BACKOFF_VEL_X_FP = 75 * ns_dynamics.SCALE_FP;

--- a/8-zed/contracts/constants/constants_jessica.cairo
+++ b/8-zed/contracts/constants/constants_jessica.cairo
@@ -195,18 +195,9 @@ namespace ns_jessica_body_state_qualifiers {
     }
 
     func is_in_gatotsu_active {range_check_ptr}(state: felt, counter: felt) -> felt {
-        if (state != ns_jessica_body_state.GATOTSU) {
-            return 0;
-        }
-
-        if (counter == 3) {
+        if (state == ns_jessica_body_state.GATOTSU and (counter-3) * (counter-4) == 0) {
             return 1;
         }
-
-        if (counter == 4) {
-            return 1;
-        }
-
         return 0;
     }
 

--- a/8-zed/contracts/constants/constants_jessica.cairo
+++ b/8-zed/contracts/constants/constants_jessica.cairo
@@ -16,7 +16,7 @@ namespace ns_jessica_dynamics {
 
     const MAX_VEL_DASH_FP = 1200 * ns_dynamics.SCALE_FP;
     const MIN_VEL_DASH_FP = (-1200) * ns_dynamics.SCALE_FP;
-    const DASH_VEL_FP = 900 * ns_dynamics.SCALE_FP;
+    const DASH_VEL_FP = 700 * ns_dynamics.SCALE_FP;
 
     const KNOCK_VEL_X_FP = 150 * ns_dynamics.SCALE_FP;
     const KNOCK_VEL_Y_FP = 350 * ns_dynamics.SCALE_FP;

--- a/8-zed/contracts/constants/constants_jessica.cairo
+++ b/8-zed/contracts/constants/constants_jessica.cairo
@@ -195,7 +195,7 @@ namespace ns_jessica_body_state_qualifiers {
     }
 
     func is_in_gatotsu_active {range_check_ptr}(state: felt, counter: felt) -> felt {
-        if (state == ns_jessica_body_state.GATOTSU and (counter-3) * (counter-4) == 0) {
+        if (state == ns_jessica_body_state.GATOTSU and (counter-4) * (counter-5) == 0) {
             return 1;
         }
         return 0;

--- a/8-zed/contracts/dynamics.cairo
+++ b/8-zed/contracts/dynamics.cairo
@@ -208,13 +208,21 @@ func _euler_forward_no_hitbox {range_check_ptr}(
         jmp update_vel_move;
     }
 
-    if (state == DASH_FORWARD) {
+    if ( (state-DASH_FORWARD) * (state-DASH_BACKWARD) == 0 ) {
+
+        local dir_multiplier;
+        if (state == DASH_FORWARD) {
+            assert dir_multiplier = 1;
+        } else {
+            assert dir_multiplier = -1;
+        }
+
         // prepare dash initial velocity of magnitude DASH_VEL_FP
         local vel_dash;
-        if (dir == 1) {
-            assert vel_dash = DASH_VEL_FP;
+        if (dir == RIGHT) {
+            assert vel_dash = dir_multiplier * DASH_VEL_FP;
         } else {
-            assert vel_dash = (-1) * DASH_VEL_FP;
+            assert vel_dash = (-1) * dir_multiplier * DASH_VEL_FP;
         }
 
         if (counter == 0) {
@@ -231,9 +239,9 @@ func _euler_forward_no_hitbox {range_check_ptr}(
                 assert vel_fp_x = last_vel_fp_x;
 
                 if (dir == RIGHT) {
-                    assert acc_fp_x = (-1) * ns_dynamics.FRICTION_ACC_FP;
+                    assert acc_fp_x = (-1) * dir_multiplier * ns_dynamics.FRICTION_ACC_FP;
                 } else {
-                    assert acc_fp_x = ns_dynamics.FRICTION_ACC_FP;
+                    assert acc_fp_x = dir_multiplier * ns_dynamics.FRICTION_ACC_FP;
                 }
             }
         }
@@ -241,29 +249,49 @@ func _euler_forward_no_hitbox {range_check_ptr}(
         assert vel_fp_y = 0;
         assert acc_fp_y = 0;
 
+        local vx_max;
+        local vx_min;
+        if (dir == RIGHT) {
+            if (state == DASH_FORWARD) {
+                assert vx_max = MAX_VEL_DASH_FP;
+                assert vx_min = 0;
+            } else {
+                assert vx_max = 0;
+                assert vx_min = (-1) * MAX_VEL_DASH_FP;
+            }
+        } else {
+            if (state == DASH_FORWARD) {
+                assert vx_max = 0;
+                assert vx_min = (-1) * MAX_VEL_DASH_FP;
+            } else {
+                assert vx_max = MAX_VEL_DASH_FP;
+                assert vx_min = 0;
+            }
+        }
+
         tempvar range_check_ptr = range_check_ptr;
         jmp update_vel_with_init_vel_cap_0_directionally;
     }
 
-    if (state == DASH_BACKWARD) {
-        // prepare the dash at counter==1
-        // dash with vel = DASH_VEL_FP
-        local vel;
-        if (dir == 1) {
-            assert vel = (-1) * DASH_VEL_FP;
-        } else {
-            assert vel = DASH_VEL_FP;
-        }
-        if (counter == 1) {
-            assert vel_fp_nxt = Vec2(vel, 0);
-        } else {
-            assert vel_fp_nxt = Vec2(0, 0);
-        }
-        assert acc_fp_x = 0;
-        assert acc_fp_y = 0;
-        tempvar range_check_ptr = range_check_ptr;
-        jmp update_pos;
-    }
+    // if (state == DASH_BACKWARD) {
+    //     // prepare the dash at counter==1
+    //     // dash with vel = DASH_VEL_FP
+    //     local vel;
+    //     if (dir == 1) {
+    //         assert vel = (-1) * DASH_VEL_FP;
+    //     } else {
+    //         assert vel = DASH_VEL_FP;
+    //     }
+    //     if (counter == 1) {
+    //         assert vel_fp_nxt = Vec2(vel, 0);
+    //     } else {
+    //         assert vel_fp_nxt = Vec2(0, 0);
+    //     }
+    //     assert acc_fp_x = 0;
+    //     assert acc_fp_y = 0;
+    //     tempvar range_check_ptr = range_check_ptr;
+    //     jmp update_pos;
+    // }
 
     if ( (state-HURT) * (state-CLASH) == 0 ) {
         local vel;
@@ -558,15 +586,6 @@ func _euler_forward_no_hitbox {range_check_ptr}(
     update_vel_with_init_vel_cap_0_directionally:
     // reusing dash's max & min velocity for knocked physics for now
     // note: only x-axis velocity is capped by max & min
-    local vx_max;
-    local vx_min;
-    if (dir == RIGHT) {
-        assert vx_max = MAX_VEL_DASH_FP;
-        assert vx_min = 0;
-    } else {
-        assert vx_max = 0;
-        assert vx_min = (-1) * MAX_VEL_DASH_FP;
-    }
     let (vel_fp_nxt_: Vec2) = _euler_forward_vel_no_hitbox(
         Vec2(vel_fp_x, vel_fp_y),
         Vec2(acc_fp_x, acc_fp_y),
@@ -645,18 +664,28 @@ func _cap_fp{range_check_ptr}(x_fp: felt, max_fp: felt, min_fp: felt) -> (x_fp_c
     return (x_fp,);
 }
 
-func _is_cap_fp{range_check_ptr}(x_fp: felt, max_fp: felt, min_fp: felt) -> (is_x_fp_capped: felt) {
-    let is_max = x_fp - max_fp;
-    if (is_max == 0) {
-        return (is_x_fp_capped=1);
-    }
+func _is_cap_fp{range_check_ptr}(x_fp: felt, max_fp: felt, min_fp: felt) -> felt {
 
-    let is_min = x_fp - min_fp;
-    if (is_min == 0) {
-        return (is_x_fp_capped=1);
-    }
 
-    return (is_x_fp_capped=0);
+    let bool_ge_max = is_le(max_fp, x_fp);
+    let bool_le_min = is_le(x_fp, min_fp);
+
+    if ( (bool_ge_max-1) * (bool_le_min-1) == 0 ) {
+        return 1;
+    }
+    return 0;
+
+    // let is_max = isx_fp - max_fp;
+    // if (is_max == 0) {
+    //     return (is_x_fp_capped=1);
+    // }
+
+    // let is_min = x_fp - min_fp;
+    // if (is_min == 0) {
+    //     return (is_x_fp_capped=1);
+    // }
+
+    // return (is_x_fp_capped=0);
 }
 
 //##
@@ -720,8 +749,8 @@ func _euler_forward_consider_hitbox{range_check_ptr}(
 
         // check if agent against the boundaries
         // only use the speed of unbounded agents
-        let (is_capped_0) = _is_cap_fp(physics_state_cand_0.pos.x, ns_scene.X_MAX, ns_scene.X_MIN);
-        let (is_capped_1) = _is_cap_fp(physics_state_cand_1.pos.x, ns_scene.X_MAX, ns_scene.X_MIN);
+        let is_capped_0 = _is_cap_fp(physics_state_cand_0.pos.x, ns_scene.X_MAX, ns_scene.X_MIN);
+        let is_capped_1 = _is_cap_fp(physics_state_cand_1.pos.x, ns_scene.X_MAX, ns_scene.X_MIN);
         if (is_capped_0 == 1) {
             assert move_0 = 0;
             assert move_1 = 1;

--- a/8-zed/contracts/engine.cairo
+++ b/8-zed/contracts/engine.cairo
@@ -197,7 +197,7 @@ func loop{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
     assert arr_frames[0] = FrameScene(
         agent_0 = Frame(
             mental_state  = agent_0_initial_state,
-            body_state    = BodyState(0, 0, ns_integrity.INIT_INTEGRITY, 500, 1, 0, 0, -1),
+            body_state    = BodyState(0, 0, ns_integrity.INIT_INTEGRITY, ns_stamina.INIT_STAMINA, 1, 0, 0, -1),
             physics_state = physics_state_0,
             action        = 0,
             stimulus      = ns_stimulus.GROUND * ns_stimulus.ENCODING,

--- a/8-zed/contracts/engine.cairo
+++ b/8-zed/contracts/engine.cairo
@@ -197,7 +197,7 @@ func loop{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
     assert arr_frames[0] = FrameScene(
         agent_0 = Frame(
             mental_state  = agent_0_initial_state,
-            body_state    = BodyState(0, 0, ns_integrity.INIT_INTEGRITY, ns_stamina.INIT_STAMINA, 1, 0, 0, -1),
+            body_state    = BodyState(0, 0, ns_integrity.INIT_INTEGRITY, 500, 1, 0, 0, -1),
             physics_state = physics_state_0,
             action        = 0,
             stimulus      = ns_stimulus.GROUND * ns_stimulus.ENCODING,


### PR DESCRIPTION
### Description
This PR fixes 2 bugs:

#### Bug 1
**Jessica's dash could push the opponent's body outside of the wall**, causing all kinds of problems including camera panning issue. The root cause of this push is at least two-part:

(1) The way we handle dash physics in the smart contract: 
- We apply dash initial velocity at dash's 2nd frame, and immediately hard-set the character's velocity to 0 in the 3rd frame. 
- When up close against a _static_ opponent, in the 3rd frame the character's body overlaps with opponent's body, triggering collision handling logic.
- Our collision handling logic looks at the velocity of colliding bodies, and _back them off_ to resolve overlap; the backoff distance for each entity depends on the entity's velocity ie the faster moving entity would back off more.
- Because our character's body has 0 velocity in the 3rd frame when overlapping with the opponent's body which is also static, both character backs off - opponent backs off too, which we don't want.

**If only the dashing character has velocity when overlapping with the static opponent**, the collision handling logic would have only backed off the dashing character, not the opponent.

(1) The logic that detects character out-of-wall is incorrect.

#### Bug 2
**Jessica's Gatotsu has incorrect action hitbox positioning**. Specifically, Gatotsu has two active frames; the action hitbox of one of the frames is detached from the body. Our physics simulation forwards the system in two passes: the first pass does not consider overlap and produces candidate body positions; the second pass resolves all overlaps among the candidate body positions, producing the final body position. The root cause of this bug is our action hitbox positioning logic was placed incorrectly after the first pass, hence using the candidate positions instead of the final positions.

### Approach

#### Bug 1
1. Apply initial velocity to both forward & backward dash, but diminish the velocity with high friction instead of force-setting the velocity to 0. This allows the dashing body to have >0 velocity when overlapping with a static opponent. This helps reduce the chances of Jessica pushing the opponent back.
2. Fix out-of-wall detection logic. This largely prevents Jessica's opponent from being pushed outside the wall.

Note: in case of Gatotsu used at the corner, the opponent would still spill outside the wall. This physics problem should be fixed in a later PR.

#### Bug 2
Compute action hitbox after the second pass of physics simulation to use the finalized body positions.

### Result

#### Bug 1
https://github.com/topology-gg/shoshin/assets/59590480/3e433f14-969c-4c24-a84c-34bdcfb4f98a

#### Bug 2
