### PR TITLE
Make KO end after landing

### DIFF
--- a/8-zed/contracts/body/body_antoc.cairo
+++ b/8-zed/contracts/body/body_antoc.cairo
@@ -60,10 +60,15 @@ func _body_antoc {range_check_ptr}(
         if (counter == ns_antoc_body_state_duration.KO - 1) {
             // stop at last frame
             return ( body_state_nxt = BodyState(ns_antoc_body_state.KO, counter, updated_integrity, updated_stamina, dir, is_fatigued, state_index, opponent_state_index_last_hit) );
-        } else {
-            // increment
-            return ( body_state_nxt = BodyState(ns_antoc_body_state.KO, counter + 1, updated_integrity, updated_stamina, dir, is_fatigued, state_index, opponent_state_index_last_hit) );
         }
+
+        // if reach counter==2 and still in air => remain in counter==2
+        if (counter == 2 and stimulus_type != ns_stimulus.GROUND) {
+            return ( body_state_nxt = BodyState(ns_antoc_body_state.KO, counter, updated_integrity, updated_stamina, dir, is_fatigued, state_index, opponent_state_index_last_hit) );
+        }
+
+        // increment
+        return ( body_state_nxt = BodyState(ns_antoc_body_state.KO, counter + 1, updated_integrity, updated_stamina, dir, is_fatigued, state_index, opponent_state_index_last_hit) );
     }
 
     //

--- a/8-zed/contracts/body/body_jessica.cairo
+++ b/8-zed/contracts/body/body_jessica.cairo
@@ -59,10 +59,15 @@ func _body_jessica {range_check_ptr}(
         if (counter == ns_jessica_body_state_duration.KO - 1) {
             // stop at last frame
             return ( body_state_nxt = BodyState(ns_jessica_body_state.KO, counter, updated_integrity, updated_stamina, dir, is_fatigued, state_index, opponent_state_index_last_hit) );
-        } else {
-            // increment
-            return ( body_state_nxt = BodyState(ns_jessica_body_state.KO, counter + 1, updated_integrity, updated_stamina, dir, is_fatigued, state_index, opponent_state_index_last_hit) );
         }
+
+        // if reach counter==2 and still in air => remain in counter==2
+        if (counter == 2 and stimulus_type != ns_stimulus.GROUND) {
+            return ( body_state_nxt = BodyState(ns_jessica_body_state.KO, counter, updated_integrity, updated_stamina, dir, is_fatigued, state_index, opponent_state_index_last_hit) );
+        }
+
+        // increment
+        return ( body_state_nxt = BodyState(ns_jessica_body_state.KO, counter + 1, updated_integrity, updated_stamina, dir, is_fatigued, state_index, opponent_state_index_last_hit) );
     }
 
     //

--- a/8-zed/contracts/constants/constants.cairo
+++ b/8-zed/contracts/constants/constants.cairo
@@ -24,6 +24,9 @@ namespace ns_dynamics {
     const BLOCK_BACKOFF_VEL_X_FP = 75 * ns_dynamics.SCALE_FP;
 
     const IN_AIR_VEL_X_FP = 150 * ns_dynamics.SCALE_FP;
+
+    const KO_VEL_X_FP = 0  * ns_dynamics.SCALE_FP;
+    const KO_VEL_Y_FP = 200 * ns_dynamics.SCALE_FP;
 }
 
 namespace ns_stamina {

--- a/8-zed/contracts/dynamics.cairo
+++ b/8-zed/contracts/dynamics.cairo
@@ -32,6 +32,7 @@ func _character_specific_constants {range_check_ptr}(character_type: felt) -> (
     BLOCK: felt,
     JUMP_MOVE_FORWARD: felt,
     JUMP_MOVE_BACKWARD: felt,
+    KO: felt,
 
     MAX_VEL_MOVE_FP: felt,
     MIN_VEL_MOVE_FP: felt,
@@ -67,6 +68,7 @@ func _character_specific_constants {range_check_ptr}(character_type: felt) -> (
             ns_jessica_body_state.BLOCK,
             ns_jessica_body_state.JUMP_MOVE_FORWARD,
             ns_jessica_body_state.JUMP_MOVE_BACKWARD,
+            ns_jessica_body_state.KO,
 
             ns_jessica_dynamics.MAX_VEL_MOVE_FP,
             ns_jessica_dynamics.MIN_VEL_MOVE_FP,
@@ -102,6 +104,7 @@ func _character_specific_constants {range_check_ptr}(character_type: felt) -> (
             ns_antoc_body_state.BLOCK,
             ns_antoc_body_state.JUMP_MOVE_FORWARD,
             ns_antoc_body_state.JUMP_MOVE_BACKWARD,
+            ns_antoc_body_state.KO,
 
             ns_antoc_dynamics.MAX_VEL_MOVE_FP,
             ns_antoc_dynamics.MIN_VEL_MOVE_FP,
@@ -158,6 +161,7 @@ func _euler_forward_no_hitbox {range_check_ptr}(
         BLOCK: felt,
         JUMP_MOVE_FORWARD: felt,
         JUMP_MOVE_BACKWARD: felt,
+        KO: felt,
 
         MAX_VEL_MOVE_FP: felt,
         MIN_VEL_MOVE_FP: felt,
@@ -344,14 +348,48 @@ func _euler_forward_no_hitbox {range_check_ptr}(
             // apply momentum at first frame depending on direction
             if (dir == 1) {
                 // facing right
-                assert vel_fp_y = KNOCK_VEL_Y_FP;
-                assert vel_fp_x = (-1) * KNOCK_VEL_X_FP;
+                assert vel_fp_y = physics_state.vel_fp.y + KNOCK_VEL_Y_FP;
+                assert vel_fp_x = physics_state.vel_fp.x + (-1) * KNOCK_VEL_X_FP;
                 assert acc_fp_y = 0;
                 assert acc_fp_x = 0;
             } else {
                 // facing left
-                assert vel_fp_y = KNOCK_VEL_Y_FP;
-                assert vel_fp_x = KNOCK_VEL_X_FP;
+                assert vel_fp_y = physics_state.vel_fp.y + KNOCK_VEL_Y_FP;
+                assert vel_fp_x = physics_state.vel_fp.x + KNOCK_VEL_X_FP;
+                assert acc_fp_y = 0;
+                assert acc_fp_x = 0;
+            }
+        } else {
+            // for y-axis, apply gravity
+            assert acc_fp_y = ns_dynamics.GRAVITY_ACC_FP;
+            assert acc_fp_x = 0;
+            assert vel_fp_y = physics_state.vel_fp.y;
+
+            // for x-axis, zero velocity if already touched down ie infinite friction
+            if (physics_state.pos.y == 0) {
+                assert vel_fp_x = 0;
+            } else {
+                assert vel_fp_x = physics_state.vel_fp.x;
+            }
+        }
+        tempvar range_check_ptr = range_check_ptr;
+        jmp update_vel_with_init_vel;
+    }
+
+    if (state == KO) {
+
+        if (counter == 0) {
+            // apply momentum at first frame depending on direction
+            if (dir == 1) {
+                // facing right
+                assert vel_fp_y = ns_dynamics.KO_VEL_Y_FP;
+                assert vel_fp_x = (-1) * ns_dynamics.KO_VEL_X_FP;
+                assert acc_fp_y = 0;
+                assert acc_fp_x = 0;
+            } else {
+                // facing left
+                assert vel_fp_y = ns_dynamics.KO_VEL_Y_FP;
+                assert vel_fp_x = ns_dynamics.KO_VEL_X_FP;
                 assert acc_fp_y = 0;
                 assert acc_fp_x = 0;
             }


### PR DESCRIPTION
This PR makes KO state stay at a mid-air frame until landing, then finish the animation. This fixes the issue where KO used to end with character lying while levitating.